### PR TITLE
Minor fixes for k8s env

### DIFF
--- a/build.assets/install-flex.sh
+++ b/build.assets/install-flex.sh
@@ -2,4 +2,4 @@
 
 mkdir -p /var/lib/spiffe/flex/spiffe.io~flex/creds
 cp -f /opt/spiffe/flex /var/lib/spiffe/flex/spiffe.io~flex
-cp -rf /var/lib/spiffe/creds/* /var/lib/spiffe/flex/spiffe.io~flex/
+cp -rf --dereference  /var/lib/spiffe/creds/* /var/lib/spiffe/flex/spiffe.io~flex/

--- a/build.assets/k8s/resources/spiffe.yaml
+++ b/build.assets/k8s/resources/spiffe.yaml
@@ -29,6 +29,7 @@ spec:
           {
             "name": "install",
             "image": "apiserver:5000/spiffe:latest",
+            "imagePullPolicy":"Always",
             "command": ["/opt/spiffe/install-flex.sh"],
             "volumeMounts": [
                 {
@@ -41,7 +42,7 @@ spec:
                 }
             ]
           }
-        ]'        
+        ]'
     spec:
       containers:
       - image: apiserver:5000/spiffe:latest
@@ -58,7 +59,7 @@ spec:
           - name: spiffe-run
             mountPath: /var/run/spiffe
           - name: kubelet-pods
-            mountPath: /var/lib/kubelet-pods
+            mountPath: /var/lib/kubelet/pods
       volumes:
         - name: flex-plugin
           hostPath:
@@ -70,7 +71,7 @@ spec:
           hostPath:
             path: /var/run/spiffe
         - name: spiffe-creds
-          sec/et:
+          secret:
             secretName: spiffe-creds
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
I ran into some issues on minikube. 
* The `install-flex.sh` copied the file references but not the values to the node.
* `spiffe.yaml`required pull policy, incorrect path to pod volumes See (https://github.com/kubernetes/kubernetes/issues/21931), typo