### PR TITLE
Clean up SPIFFE spec

### DIFF
--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -8,7 +8,7 @@ Distributed design patterns and practices such as microservices, container orche
 
 Further, modern developers are expected to understand and play a role in how applications are deployed and managed in production environments. Operations teams require deeper visibility into the applications they are managing. As we move to a more evolved security stance, we must offer better tools to both teams so they can play an active role in building secure, distributed applications.
 
-The SPIFFE standard provides a specification for a framework capable of bootstrapping          and issuing identity to services across heterogeneous environments and organizational boundaries.
+The SPIFFE standard provides a specification for a framework capable of bootstrapping and issuing identity to services across heterogeneous environments and organizational boundaries.
 
 ## Table of Contents
 TODO
@@ -23,16 +23,16 @@ Section 3 describes the SPIFFE Verifiable Identity Document (or SVID). An SVID i
 Section 4 acknowledges a standardized API (the Workload API) which may be used to retrieve a SPIFFE SVID, though the API itself stands independently, and is fully defined in a separate specification.
 
 ## 2. SPIFFE Identity
-In order to communicate an identity, we must first define an identity namespace. A SPIFFE Identity (or SPIFFE ID) is defined as a URI comprising a “Trust Domain” and an associated path. The Trust Domain stands as the authority component of the URI, and serves to identify the system in which a given identity is issued. The following example demonstrates how a SPIFFE ID is constructed:
+In order to communicate an identity, we must first define an identity namespace. A SPIFFE Identity (or SPIFFE ID) is defined as a URI comprising a “trust domain” and an associated path. The trust domain stands as the authority component of the URI, and serves to identify the system in which a given identity is issued. The following example demonstrates how a SPIFFE ID is constructed:
 
 ```spiffe://trust-domain/path```
 
 Valid SPIFFE IDs MUST be prefixed with the `spiffe://` scheme.
 
 ### 2.1. Trust Domain
-The Trust Domain corresponds to the trust root of a system, that is it can be assumed that the infrastructure that assigned identities under that domain has had trust pre-established prior to issuing those identities. A trust domain could represent an individual, organization, environment or department running their own independent SPIFFE infrastructure.
+The trust domain corresponds to the trust root of a system, that is it can be assumed that the infrastructure that assigned identities under that domain has had trust pre-established prior to issuing those identities. A trust domain could represent an individual, organization, environment or department running their own independent SPIFFE infrastructure.
 
-Trust domains are nominally self-registered, unlike public DNS there is no delegating authority that acts to assert and register a base domain to an actual legal real-world entity, or assert that legal entity has fair and due rights to any particular TD.
+trust domains are nominally self-registered, unlike public DNS there is no delegating authority that acts to assert and register a base domain to an actual legal real-world entity, or assert that legal entity has fair and due rights to any particular trust domain.
 
 ### 2.2. Path
 The path component of a SPIFFE name allows for the unique identification of a given workload. The meaning behind the path is left open ended and the responsibility of the administrator to define.
@@ -40,36 +40,40 @@ The path component of a SPIFFE name allows for the unique identification of a gi
 Paths MAY be hierarchical - similar to filesystem paths. The specific meaning of paths is reserved as an exercise to the implementer and are outside the SVID specification. However some examples and conventions are expressed below.
 
 * Identifying services directly
+
   Often it is valuable to identify services directly. For example, an administrator may decree that any process running on a particular set of nodes should be able to present itself as a particular identity. For example:
 
   ```spiffe://staging.acme.com/payments/mysql```
   or
   ```spiffe://staging.acme.com/payments/web-fe```
 
-  The two SPIFFE names above refer to two different components - the mysql database service and a web front-end - of a payments service running in a staging environment. The meaning of ‘staging’ as an environment, ‘payments’ as a high level service collection is defined by the implementer.
+  The two SPIFFE IDs above refer to two different components - the mysql database service and a web front-end - of a payments service running in a staging environment. The meaning of ‘staging’ as an environment, ‘payments’ as a high level service collection is defined by the implementer.
 
 * Identifying service owners
+
   Often higher level orchestrators and platforms may have their own identity concepts built in (such as Kubernetes service accounts, or AWS/GCP service accounts) and it is helpful to be able to directly map SPIFFE identities to those identities. For example:
 
   ```spiffe://k8s-west.acme.com/ns/staging/sa/default```
 
-  In this example, the administrator of acme.com is running a Kubernetes cluster k8s-west.acme.com, which has a ‘staging’ namespace, and within this a service account (sa) called ‘default’. These are conventions defined by the spiffe administrator, not assertions guaranteed in SPIFFE SVID format.
+  In this example, the administrator of acme.com is running a Kubernetes cluster k8s-west.acme.com, which has a ‘staging’ namespace, and within this a service account (sa) called ‘default’. These are conventions defined by the SPIFFE administrator, not assertions guaranteed by this specification.
 
 
 * Opaque SPIFFE idenity
-  The above examples are illustrative and, in the most general case, the SPIFFE path may be left opaque, carrying no visible hierarchical information. Metadata, such as geographical location, logical system partitioning and/or service name, may be provided by a secondary system, where identities and their attributes are registered. that can be queried to retrieve any metadata associated with the SPIFFE identifier. For example:
+
+  The above examples are illustrative and, in the most general case, the SPIFFE path may be left opaque, carrying no visible hierarchical information. Metadata, such as geographic location, logical system partitioning and/or service name, may be provided by a secondary system, where identities and their attributes are registered. that can be queried to retrieve any metadata associated with the SPIFFE identifier. For example:
 
   ```spiffe://acme.com/9eebccd2-12bf-40a6-b262-65fe0487d453```
 
 ## 3. SPIFFE Verifiable Identity Document
 A SPIFFE Verifiable Identity Document (SVID) is the mechanism through which a workload communicates its identity to a resource or caller. An SVID is considered valid if
-it has been signed by an authority within the SPIFFE IDs Trust Domain, and the presenter can prove ownership of the associated private key.
+it has been signed by an authority within the SPIFFE IDs trust domain, and the presenter can prove ownership of the associated private key.
 
 ### 3.1. SVID Trust
-As covered in Section 2.1, SPIFFE trust is rooted in a given IDs Trust Domain. A signing authority MUST exist in each Trust Domain, and this signing authority MUST carry an SVID of its own. The SVID of the signing authority then forms the basis of trust for a given Trust Domain.=
+As covered in Section 2.1, SPIFFE trust is rooted in a given ID's trust domain. A signing authority MUST exist in each trust domain, and this signing authority MUST carry an SVID of its own. The SPIFFE ID of the signing authority SHOULD reside in the trust domain in which it is authoritative, and SHOULD NOT have a path component. The SVID of the signing authority then forms the basis of trust for a given trust domain.
 
-Chaining of trust, if desired, can be achieved by signing the authority’s SVID with the private key of a foreign Trust Domain’s authority. In the event that trust is not being chained, then the authority’s SVID is self-signed.
-3.2. SVID Components
+Chaining of trust, if desired, can be achieved by signing the authority’s SVID with the private key of a foreign trust domain’s authority. In the event that trust is not being chained, then the authority’s SVID is self-signed.
+
+### 3.2. SVID Components
 An SVID is a fairly simple construct, and comprises three basic components:
 
 * A SPIFFE ID


### PR DESCRIPTION
This PR cleans up some typos, capitalization etc in the SPIFFE spec. It also clarifies what the SPIFFE ID of a signing authority should be. This sets us up for further clarity in the X.509 spec I'm currently working on

Related to #2 