### PR TITLE
In the X.509 SVID spec, clarify key usage requirements for CAs.

### DIFF
--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -70,9 +70,9 @@ The key usage extension defines the purpose of the key contained in the certific
 
 The key usage extension MUST be set on all SVIDs, and MUST be marked critical.
 
-SVID signing certificates MUST set `keyCertSign` and `cRLSign`. They MUST NOT set `keyEncipherment` or `keyAgreement`. This helps ensure that they cannot be used for authentication purposes.
+SVID signing certificates MUST set `keyCertSign`. They MAY set `cRLSign`.
 
-Leaf SVIDs MUST set `keyEncipherment`, `keyAgreement`, and `digitalSignature`. They MUST NOT set `keyCertSign` or `cRLSign`.
+Leaf SVIDs MUST set `digitalSignature`. They MAY set `keyEncipherment` and/or `keyAgreement`; these mostly make sense only for certificates for RSA keys, and usually they aren't needed even then. Leaf SVIDs MUST NOT set `keyCertSign` or `cRLSign`.
 
 ### 4.4. Extended Key Usage
 This extension indicates one or more purposes for which the key contained in the certificate may be used, in addition to or in place of the basic purposes indicated in the key usage extension. It is defined in [RFC 5280, section 4.2.1.2][6].


### PR DESCRIPTION
Signing certificates don't need to set cRLSign, and the probably shouldn't if
they know they aren't going to issue CRLs.

Leaf certificates don't need to set `keyAgreement` or `keyEncipherment` if they
are never going to be used for key agreement or key encipherment. For example,
a leaf certificate with an ECC key is probably only going to be used for signing
ECDSA/EdDSA signatures. A leaf certificate with an RSA key likely should have
`keyEncipherment` so that it can be used for RSA key exchange, but if only
(EC)DHE-based key exchange is to be used then it isn't needed.