### PR TITLE
In the X.509 SVID spec, make EKU requirements more flexible.

### DIFF
--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -77,9 +77,10 @@ Leaf SVIDs MUST set `keyEncipherment`, `keyAgreement`, and `digitalSignature`. T
 ### 4.4. Extended Key Usage
 This extension indicates one or more purposes for which the key contained in the certificate may be used, in addition to or in place of the basic purposes indicated in the key usage extension. It is defined in [RFC 5280, section 4.2.1.2][6].
 
-The extended key usage extension applies to leaf certificates only. Leaf SVIDs SHOULD include this extension, and it MAY be marked as critical. When included, fields `id-kp-serverAuth` and `id-kp-clientAuth` MUST be set, and all other fields MUST NOT be set.
+Leaf SVIDs SHOULD include this extension, and it MAY be marked as critical. When included, fields `id-kp-serverAuth` and `id-kp-clientAuth` MUST be set.
 
-Signing certificates MUST NOT include an Extended Key Usage extension.
+Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension
+in intermediate CA certificates varies widely across X.509 certificate validation libraries.
 
 ## 5. Validation
 This section describes how an X.509 SVID is validated. The procedure uses standard X.509 validation, in addition to a small set of SPIFFE-specific validation steps.

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -79,8 +79,7 @@ This extension indicates one or more purposes for which the key contained in the
 
 Leaf SVIDs SHOULD include this extension, and it MAY be marked as critical. When included, fields `id-kp-serverAuth` and `id-kp-clientAuth` MUST be set.
 
-Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension
-in intermediate CA certificates varies widely across X.509 certificate validation libraries.
+Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension in intermediate CA certificates varies widely across X.509 certificate validation libraries.
 
 ## 5. Validation
 This section describes how an X.509 SVID is validated. The procedure uses standard X.509 validation, in addition to a small set of SPIFFE-specific validation steps.

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -79,7 +79,7 @@ This extension indicates one or more purposes for which the key contained in the
 
 Leaf SVIDs SHOULD include this extension, and it MAY be marked as critical. When included, fields `id-kp-serverAuth` and `id-kp-clientAuth` MUST be set.
 
-Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension in intermediate CA certificates varies widely across X.509 certificate validation libraries. Some X.509 implementations will impose EKU constraints in intermediate CA certificates on all certificates below them in the trust chain, and others will not.
+Signing certificates MAY include an Extended Key Usage extension. Note that the processing of the Extended Key Usage extension in intermediate CA certificates varies widely across X.509 certificate validation libraries. Some X.509 implementations will impose EKU constraints in intermediate CA certificates on all certificates below them in the trust chain, and others will not.
 
 ## 5. Validation
 This section describes how an X.509 SVID is validated. The procedure uses standard X.509 validation, in addition to a small set of SPIFFE-specific validation steps.

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -79,7 +79,7 @@ This extension indicates one or more purposes for which the key contained in the
 
 Leaf SVIDs SHOULD include this extension, and it MAY be marked as critical. When included, fields `id-kp-serverAuth` and `id-kp-clientAuth` MUST be set.
 
-Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension in intermediate CA certificates varies widely across X.509 certificate validation libraries.
+Signing certificates SHOULD NOT include an Extended Key Usage extension because the processing of the Extended Key Usage extension in intermediate CA certificates varies widely across X.509 certificate validation libraries. Some X.509 implementations will impose EKU constraints in intermediate CA certificates on all certificates below them in the trust chain, and others will not.
 
 ## 5. Validation
 This section describes how an X.509 SVID is validated. The procedure uses standard X.509 validation, in addition to a small set of SPIFFE-specific validation steps.


### PR DESCRIPTION
Leave the door open for future work on EKU restrictions in intermediate
CA certifictes.

An empty EKU field means "all EKUs are allowed." Therefore, it doesn't
make much sense to allow an empty EKU but then forbid EKUs that have
EKUs other than id-kp-serverAuth and id-kp-clientAuth; if other EKUs
are truly harmful to be included then a missing EKU extension should be
forbidden too.