### PR TITLE
Remove SPIFFE ID matching & SKI/AKI matching from X.509 spec.

### DIFF
--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -94,9 +94,7 @@ When authenticating a resource or caller, it is necessary to perform validation 
 
 When validating an X.509 SVID for authentication purposes, the validator MUST ensure that the `CA` field in the basic constraints extension is set to `false`, and that `keyCertSign` and `cRLSign` are not set in the key usage extension. The validator must also ensure that the scheme of the SPIFFE ID is set to `spiffe://`.
 
-It is the responsibility of the validator to ensure that the certificate used to sign the leaf is in fact an authority for the trust domain that the leaf resides in. Specifically, the SPIFFE ID of the signing certificate MUST be equal to the leaf certificate’s SPIFFE trust domain. In the context of X.509, the leaf’s signing certificate is the one with a Subject Key Identifier (SKID) equal to the Authority Key Identifier (AKID) set on the leaf certificate. This validation step is only performed between the leaf and its immediate signing certificate. That is to say, it does not proceeed all the way up the trust chain.
-
-Validation of the signing authority in this manner is necessary due to lack of widespread support for X.509 URI name constraints (see [section 4.2](#4.2.-name-constraints)). As support for URI name constraints becomes more widespread, future versions this document may update the requirements set forth in this section in order to better leverage name constraint validation.
+As support for URI name constraints becomes more widespread, future versions this document may update the requirements set forth in this section in order to better leverage name constraint validation.
 
 ## 6. Conclusion
 This document set forth conventions and standards for the issuance and validation of X.509-based SPIFFE Verifiable Identity Documents. It forms the basis for real world SPIFFE service authentication and SVID validation. By conforming to the X.509 SVID standard, it is possible to build an identity and authentication system which is interoperable and platform agnostic.


### PR DESCRIPTION
Matching the SPIFFE ID and SKI/AKI in the leaf to its immediate
issuing certificate is non-standard (in X.509 terms) behavior that is
difficult to implement correctly and securely, especially given the
wide variety of certificate validation libraries in use. Other
mechanisms will be needed to achieve the goals these checks were
intended for. Although those new mechanisms haven't been finished yet,
that doesn't need to block the removal of these non-working checks now.

This is one step towards resolving #26.