### PR TITLE
Add trailing slash to specification CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,7 +32,7 @@
 ##
 
 # TODO: Missing Davi Ottenheimer
-/standards          @evan2645  @justinburke @mattmoyer @pragashjj @diogomonica
+/standards/         @evan2645  @justinburke @mattmoyer @pragashjj @diogomonica
 
 ##
 ## Community


### PR DESCRIPTION
Attempt to fix a problem where SPIFFE maintainers are not tagged as Reviewers for SPIFFE spec changes

@drrt 
