### PR TITLE
Remove spurious space in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,7 +32,7 @@
 ##
 
 # TODO: Missing Davi Ottenheimer
-/standards/         @evan2645  @justinburke @mattmoyer @pragashjj @diogomonica
+/standards/         @evan2645 @justinburke @mattmoyer @pragashjj @diogomonica
 
 ##
 ## Community


### PR DESCRIPTION
Second shot at trying to fix codeowner review for standards/

@drrt 