### PR TITLE
Update CODEOWNERS code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,4 +52,4 @@
 ##
 
 /.travis.yml        @drrt @evan2645
-/CODEOWNERS         @drrt @evan2645
+/CODEOWNERS         @evan2645 @jondb @jbeda @mlakewood @y2bishop2y


### PR DESCRIPTION
This commit sets the owners of the CODEOWNERS file equal to the TSC
members. Since the file tracks TSC members as well as SPIFFE
Maintainers, members of the TSC feel like the right folks to approve
changes here.

Signed-off-by: Evan Gilman <evan@scytale.io>