### PR TITLE
Fix some typos in community docs

### DIFF
--- a/community/sig-creation-procedure.md
+++ b/community/sig-creation-procedure.md
@@ -15,7 +15,7 @@
 * Add the meeting to the community meeting calendar by inviting {TODO}@group.calendar.google.com.  
 * Announce new SIG on spiffe-dev@googlegroups.com
 * Submit a PR to add a row for the SIG to the table in the [README](../README.md) file, to create a
-  spiffe/community directory, and to add any SIG-releated docs, schedules, roadmaps, etc. to your
+  spiffe/community directory, and to add any SIG-related docs, schedules, roadmaps, etc. to your
   new spiffe/community/SIG-foo directory.
 
 ### Creating service account for the SIG

--- a/community/sig-integration-k8s/README.md
+++ b/community/sig-integration-k8s/README.md
@@ -12,7 +12,7 @@ A Special Interest Group (SIG) for running SPIFFE in Kubernetes. We encourage at
 * [Google Group](https://groups.google.com/a/spiffe.io/forum/#!forum/sig-integration-k8s)
 
 ### Goals:
-* Provide SPIFFE framework (node/workload identity, and attestion service with providers) to adapt to Kubernetes workloads
+* Provide SPIFFE framework (node/workload identity, and attestation service with providers) to adapt to Kubernetes workloads
 * Work with Kubernetes community
 	- [Kubernets Auth SIG](https://github.com/kubernetes/community/tree/master/sig-auth)
 	- [Kubernetes Identity WG](https://docs.google.com/document/d/1bCK-1_Zy2WfsrMBJkdaV72d2hidaxZBhS5YQHAgscPI/edit)


### PR DESCRIPTION
1. "SIG-releated" to "SIG-related" in line 18.
2. "attestion" to "attestation" in line 15.