### PR TITLE
Add ID length support requirements

### DIFF
--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -74,6 +74,10 @@ Paths MAY be hierarchical - similar to filesystem paths. The specific meaning of
 
   ```spiffe://example.com/9eebccd2-12bf-40a6-b262-65fe0487d453```
 
+### 2.3. Maximum SPIFFE ID Length
+
+URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs of at least 2048 characters in length, but MAY support longer. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 characters.
+
 ## 3. SPIFFE Verifiable Identity Document
 A SPIFFE Verifiable Identity Document (SVID) is the mechanism through which a workload communicates its identity to a resource or caller. An SVID is considered valid if it has been signed by an authority within the SPIFFE ID's trust domain.
 

--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -77,7 +77,7 @@ Paths MAY be hierarchical - similar to filesystem paths. The specific meaning of
 
 ### 2.3. Maximum SPIFFE ID Length
 
-URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs of at least 2048 bytes in length, but MAY support longer. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 bytes.
+URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs up to 2048 bytes in length and SHOULD NOT generate URIs of length greater than 2048 bytes. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 bytes.
 
 ## 3. SPIFFE Verifiable Identity Document
 A SPIFFE Verifiable Identity Document (SVID) is the mechanism through which a workload communicates its identity to a resource or caller. An SVID is considered valid if it has been signed by an authority within the SPIFFE ID's trust domain.

--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -15,6 +15,7 @@ For more general information about SPIFFE, please see the [Secure Production Ide
 2\. [SPIFFE Identity](#2-spiffe-identity)  
 2.1. [Trust Domain](#21-trust-domain)  
 2.2. [Path](#22-path)  
+2.3. [Maximum SPIFFE ID Length](#23-maximum-spiffe-id-length)
 3\. [SPIFFE Verifiable Identity Document](#3-spiffe-verifiable-identity-document)  
 3.1. [SVID Trust](#31-svid-trust)  
 3.2. [SVID Components](#32-svid-components)  

--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -77,7 +77,9 @@ Paths MAY be hierarchical - similar to filesystem paths. The specific meaning of
 
 ### 2.3. Maximum SPIFFE ID Length
 
-URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs up to 2048 bytes in length and SHOULD NOT generate URIs of length greater than 2048 bytes. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 bytes.
+URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs up to 2048 bytes in length and SHOULD NOT generate URIs of length greater than 2048 bytes. [RFC 3986](https://tools.ietf.org/html/rfc3986) permits only ASCII characters, thus the maximum length of a SPIFFE ID is 2048 bytes.
+
+All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Non-ASCII characters contribute to the URI length after they are percent encoded as ASCII characters. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 bytes.
 
 ## 3. SPIFFE Verifiable Identity Document
 A SPIFFE Verifiable Identity Document (SVID) is the mechanism through which a workload communicates its identity to a resource or caller. An SVID is considered valid if it has been signed by an authority within the SPIFFE ID's trust domain.

--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -77,7 +77,7 @@ Paths MAY be hierarchical - similar to filesystem paths. The specific meaning of
 
 ### 2.3. Maximum SPIFFE ID Length
 
-URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs of at least 2048 characters in length, but MAY support longer. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 characters.
+URIs, as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986), do not have a maximal length. As an interoperability consideration, SPIFFE implementations MUST support SPIFFE URIs of at least 2048 bytes in length, but MAY support longer. All URI components contribute to the URI length, including the "spiffe" scheme, "://" separator, trust domain, and path component. Note that [RFC 3986](https://tools.ietf.org/html/rfc3986) defines a maximum length of 255 characters for the "host" component of a URI; therefore a maximum length of a trust domain is 255 bytes.
 
 ## 3. SPIFFE Verifiable Identity Document
 A SPIFFE Verifiable Identity Document (SVID) is the mechanism through which a workload communicates its identity to a resource or caller. An SVID is considered valid if it has been signed by an authority within the SPIFFE ID's trust domain.


### PR DESCRIPTION
Discussed in March 6, 2019 SIG-Spec meeting. This change adds requirements to minimally support SPIFFE ID URIs of length 2048 characters.