### PR TITLE
Fix pathLenConstraint requirements

### DIFF
--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -59,9 +59,7 @@ Leaf and signing certificates carry different X.509 properties - some for securi
 ### 4.1. Basic Constraints
 The basic constraints X.509 extension identifies whether the certificate is a signing certificate, as well as the maximum depth of valid certification paths that include this certificate. It is defined in [RFC 5280, section 4.2.1.9][3].
 
-Non-self-issued intermediate X.509 SVID signing certificates MUST set the `pathLenConstraint` field. Signing certificates MUST set the `cA` field to `true`, and leaf certificates MUST set the `cA` field to `false`.
-
-Note that the requirements for basic constraints on X.509 SVID certificates MUST adhere to [RFC 5280, section 4.2.1.9][3]. The above text is included solely as an aid for implementors and is explicitly not intended to deviate from [RFC 5280, section 4.2.1.9][3].
+Valid X.509 SVID signing certificates MAY set the `pathLenConstraint` field. Signing certificates MUST set the `cA` field to `true`, and leaf certificates MUST set the `cA` field to `false`.
 
 ### 4.2. Name Constraints
 Name constraints indicate a namespace within which all SPIFFE IDs in subsequent certificates in a certification path MUST be located. They are used to limit the blast radius of a compromised signing certificate to the named trust domain(s), and are defined in [RFC 5280, section 4.2.1.10][4]. This section applies to signing certificates only.

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -61,7 +61,7 @@ The basic constraints X.509 extension identifies whether the certificate is a si
 
 Non-self-issued intermediate X.509 SVID signing certificates MUST set the `pathLenConstraint` field. Signing certificates MUST set the `cA` field to `true`, and leaf certificates MUST set the `cA` field to `false`.
 
-Note that the requirements for basic constraints on X.509 SVID certificates MUST adhere to [RFC 5280, section 4.2.1.9][3]. The above text is included solely as an aid implementors and is explicitly not intended to deviate from [RFC 5280, section 4.2.1.9][3].
+Note that the requirements for basic constraints on X.509 SVID certificates MUST adhere to [RFC 5280, section 4.2.1.9][3]. The above text is included solely as an aid for implementors and is explicitly not intended to deviate from [RFC 5280, section 4.2.1.9][3].
 
 ### 4.2. Name Constraints
 Name constraints indicate a namespace within which all SPIFFE IDs in subsequent certificates in a certification path MUST be located. They are used to limit the blast radius of a compromised signing certificate to the named trust domain(s), and are defined in [RFC 5280, section 4.2.1.10][4]. This section applies to signing certificates only.

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -59,7 +59,9 @@ Leaf and signing certificates carry different X.509 properties - some for securi
 ### 4.1. Basic Constraints
 The basic constraints X.509 extension identifies whether the certificate is a signing certificate, as well as the maximum depth of valid certification paths that include this certificate. It is defined in [RFC 5280, section 4.2.1.9][3].
 
-Valid X.509 SVIDs (both leaf and signing certificates) MAY set the `pathLenConstraint` field. Signing certificates MUST set the `CA` field to `true`, and leaf certificates MUST set the `CA` field to `false`.
+Non-self-issued intermediate X.509 SVID signing certificates MUST set the `pathLenConstraint` field. Signing certificates MUST set the `cA` field to `true`, and leaf certificates MUST set the `cA` field to `false`.
+
+Note that the requirements for basic constraints on X.509 SVID certificates MUST adhere to [RFC 5280, section 4.2.1.9][3]. The above text is included solely as an aid implementors and is explicitly not intended to deviate from [RFC 5280, section 4.2.1.9][3].
 
 ### 4.2. Name Constraints
 Name constraints indicate a namespace within which all SPIFFE IDs in subsequent certificates in a certification path MUST be located. They are used to limit the blast radius of a compromised signing certificate to the named trust domain(s), and are defined in [RFC 5280, section 4.2.1.10][4]. This section applies to signing certificates only.


### PR DESCRIPTION
Per RFC 5280, section 4.2.1.9, leaf certificates MUST NOT have a pathLenConstraint. This PR removes erroneous text for pathLenConstaint, adjusts `CA` -> `cA` for consistency with RFC 5280, and adds text to explicitly state that (at present) section 4.2.1.9 supersedes any text in this section of the spec.

Signed-off-by: Justin Burke burkej@google.com