### PR TITLE
Correct RFC 7519 reference link text

### DIFF
--- a/standards/JWT-SVID.md
+++ b/standards/JWT-SVID.md
@@ -80,7 +80,7 @@ The `exp` claim MUST be set, and validators MUST reject tokens without this clai
 ## 4. Token Signing and Validation
 JWT-SVID signing and validation semantics are the same as regular JWTs/JWSs. Validators MUST ensure that the `alg` header is set to a supported value before processing.
 
-JWT-SVID signatures are computed and validated following the steps outlined in [RFC 7515 section 7][2]. The `aud` and `exp` claims MUST be present and processed according to [RFC 7519][1] sections [4.1.3][3] and [4.1.4][4]. Validators receiving tokens without the `aud` and `exp` claims set MUST reject the token.
+JWT-SVID signatures are computed and validated following the steps outlined in [RFC 7519 section 7][2]. The `aud` and `exp` claims MUST be present and processed according to [RFC 7519][1] sections [4.1.3][3] and [4.1.4][4]. Validators receiving tokens without the `aud` and `exp` claims set MUST reject the token.
 
 ## 5. Token Transmission
 This section describes the manner in which a JWT-SVID may be transmitted from one workload to another.


### PR DESCRIPTION
The actual link url on line 134 is `[2]: https://tools.ietf.org/html/rfc7519#section-7` which points to the correct RFC and section on verifying a JWT encoded as a JWS, but the link text previously read 7515, rather than 7519.