### PR TITLE
Add Andrew Harding to SPIFFE codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@
 ## SPIFFE Maintainers
 ##
 
-/standards/         @evan2645 @justinburke @mattmoyer @pragashj @spikecurtis
+/standards/         @evan2645 @justinburke @pragashj @spikecurtis @azdagron
 
 ##
 ## Community


### PR DESCRIPTION
Andrew Harding has been participating in SPIFFE's SIG-Spec for over a
year now. In the last six months, his participation has stepped up
greatly. He takes action items, helps with day-to-day SPIFFE
specification maintenance, and provides a great deal of input to
specifications that are underway. He has been fulfilling all the duties
of a SPIFFE maintainer, yet is not a SPIFFE maintainer.

This PR puts Andrew in Matt Moyer's seat. Matt committed a great deal of
his time and energy to the SPIFFE project in its formative days, and was
instrumental in helping the group stay pointed in the right direction.
While Matt has not been actively engaged for some time now, we thank him
very much for everything he has done.

@justinburke @spikecurtis @mattmoyer @azdagron

Signed-off-by: Evan Gilman <egilman@vmware.com>