### PR TITLE
Update link to java-spiffe repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ SPIFFE is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CN
 * [spiffe](https://github.com/spiffe/spiffe): This repository includes the SPIFFE ID, SVID and Workload API specifications, example code, and tests, as well as project governance, policies, and processes.    
 * [spire](https://github.com/spiffe/spire): This is a reference implementation of SPIFFE and the SPIFFE Workload API that can be run on and across varying hosting environments.
 * [go-spiffe](https://github.com/spiffe/go-spiffe/tree/master/v2): Golang client libraries.
-* [java-spiffe](https://github.com/spiffe/java-spiffe/tree/v2-api): Java client libraries
+* [java-spiffe](https://github.com/spiffe/java-spiffe): Java client libraries
 
 ### Communications
 


### PR DESCRIPTION
Minor change in README: replace java-spiffe repo link to point to master, as it has the latest version
