### PR TITLE
Cleanup vertical formatting of SPIFFE-ID.md table of contents

### DIFF
--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -11,17 +11,18 @@ This document, in particular, serves as the core specification for the SPIFFE st
 For more general information about SPIFFE, please see the [Secure Production Identity Framework for Everyone (SPIFFE)](SPIFFE.md) standard.
 
 ## Table of Contents
-1\. [Introduction](#1-introduction)
-2\. [SPIFFE Identity](#2-spiffe-identity)
-2.1. [Trust Domain](#21-trust-domain)
-2.1.1. [Trust Domain Name Collisions](#211-trust-domain-name-collisions)
-2.2. [Path](#22-path)
-2.3. [Maximum SPIFFE ID Length](#23-maximum-spiffe-id-length)
-3\. [SPIFFE Verifiable Identity Document](#3-spiffe-verifiable-identity-document)
-3.1. [SVID Trust](#31-svid-trust)
-3.2. [SVID Components](#32-svid-components)
-3.3. [SVID Format](#33-svid-format)
-4\. [Conclusion](#4-conclusion)
+
+1\. [Introduction](#1-introduction)  
+2\. [SPIFFE Identity](#2-spiffe-identity)  
+2.1. [Trust Domain](#21-trust-domain)  
+2.1.1. [Trust Domain Name Collisions](#211-trust-domain-name-collisions)  
+2.2. [Path](#22-path)  
+2.3. [Maximum SPIFFE ID Length](#23-maximum-spiffe-id-length)  
+3\. [SPIFFE Verifiable Identity Document](#3-spiffe-verifiable-identity-document)  
+3.1. [SVID Trust](#31-svid-trust)  
+3.2. [SVID Components](#32-svid-components)  
+3.3. [SVID Format](#33-svid-format)  
+4\. [Conclusion](#4-conclusion)  
 
 ## 1. Introduction
 This document sets forth the official SPIFFE specification. It defines the two most fundamental components of the SPIFFE standard: the SPIFFE Identity and the SPIFFE Verifiable Identity document.


### PR DESCRIPTION
The other standards Markdown files use vertical formatting for the table of contents, which is easier to read than when all the items are on a single line. Add a couple spaces at the end of each table of contents line to force Markdown to insert newlines in-between each rendered table of contents item.