### PR TITLE
Add SPIFFE Steering Committee Charter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 __pycache__
 *.pyc
 *.swp

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -16,4 +16,4 @@ We follow the [CNCF Contributor Code of Conduct](https://github.com/cncf/foundat
 
 ### Moderation
 
-- If you feel any of SPIFFE's Slack channels require moderation, please e-mail [SPIFFE's Technical Steering Committee (TSC)](mailto:tsc@spiffe.io). The TSC will issue a warning to users who don't follow this code of conduct. A second offense results in a temporary ban. A third offense warrants a permanent ban. It is at the moderator's discretion to un-ban offending users, or to immediately ban a toxic user without warning.
+- If you feel any of SPIFFE's communication channels require moderation, please e-mail the [SPIFFE Steering Committee (SSC)](mailto:ssc@spiffe.io). The SSC will issue a warning to users who don't follow this code of conduct. A second offense results in a temporary ban. A third offense warrants a permanent ban. It is at the moderator's discretion to un-ban offending users, or to immediately ban a toxic user without warning.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,55 +1,12 @@
 ##
-## SPIFFE Technical Steering Committee
-## https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md
-## tsc@spiffe.io
-##
-
-# Emiliano Berenbaum
-# https://github.com/y2bishop2y
-# https://www.linkedin.com/in/eberenb
-
-# Evan Gilman
-# https://github.com/evan2645
-# https://www.linkedin.com/in/evan2645
-
-# Jon Debonis
-# https://github.com/jondb
-# https://www.linkedin.com/in/jondb
-
-# Joseph Beda
-# https://github.com/jbeda
-# https://www.linkedin.com/in/jbeda
-
-# Mark Lakewood
-# https://github.com/mlakewood
-# https://www.linkedin.com/in/marklakewood
-
-/GOVERNANCE.md      @evan2645 @jondb @jbeda @mlakewood @y2bishop2y
-/CODE-OF-CONDUCT.md @evan2645 @jondb @jbeda @mlakewood @y2bishop2y
-
-##
 ## SPIFFE Maintainers
 ##
 
-/standards/         @evan2645 @justinburke @pragashj @spikecurtis @azdagron
+*  @evan2645 @justinburke @spikecurtis @azdagron
 
-##
-## Community
-##
+/CODE-OF-CONDUCT.md @spiffe/ssc
+/GOVERNANCE.md      @spiffe/ssc
+/README.md          @spiffe/ssc
+/community/         @spiffe/ssc
+/ssc/               @spiffe/ssc
 
-/community/         @drrt @ajessup @y2bishop2y @evan2645
-/README.md          @drrt @ajessup @y2bishop2y @evan2645
-/CONTRIBUTING.md    @drrt @ajessup @y2bishop2y @evan2645
-
-##
-## SVID Test Suite
-##
-
-/svid-test/         @drrt @evan2645
-
-##
-## Misc
-##
-
-/.travis.yml        @drrt @evan2645
-/CODEOWNERS         @evan2645 @jondb @jbeda @mlakewood @y2bishop2y

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,11 +15,11 @@ SPIFFE community members represent the project and their fellow contributors. We
 
 ### Users
 
-These are individuals who 1) want to learn more about the SPIFFE Project; or 2) are existing users of SPIFFE and its tools who wish to follow the Project's progress. They may have questions, comments, or suggestions that can be communicated via [e-mail](https://groups.google.com/a/spiffe.io/forum/#!forum/user-discussion), Slack, or GitHub comments. They can follow along as the Project's special interest groups (SIGs) do their work.
+These are individuals who 1) want to learn more about the SPIFFE Project; or 2) are existing users of SPIFFE and its tools who wish to follow the Project's progress. They may have questions, comments, or suggestions that can be communicated via Slack, GitHub, or during community calls and events. They can follow along as the Project's special interest groups (SIGs) do their work.
 
 ### Contributors
 
-These are individuals who wish to contribute code or ideas to SPIFFE projects. Contributors submit code and ideas through GitHub pull requests (PRs) and Issues. To contribute code, they or their employer must have a signed [Contributor License Agreement](/CONTRIBUTING.md) on file.
+These are individuals who wish to contribute code or ideas to SPIFFE projects. Contributors submit code and ideas through GitHub or through participation in SPIFFE's community calls.
 
 ### Maintainers
 
@@ -43,34 +43,35 @@ The process for nominating and approving Maintainers is:
 * Open a PR against the CODEOWNERS file that covers the parts of the project you wish to nominate someone (or yourself) for
 * A consensus of existing Maintainers must approve your PR
 
-### Technical Steering Committee (TSC)
+### The SPIFFE Steering Committee (SSC)
 
-The SPIFFE Project is governed by a [TSC](https://github.com/spiffe/spiffe/blob/master/CODEOWNERS) that is exclusively responsible for SPIFFE's [standards](https://github.com/spiffe/spiffe/tree/master/standards) and the Project's strategic goals and direction. In addition to the rights and privileges of Maintainers, TSC members have final authority over:
+The SPIFFE Project is governed by the [SSC](https://github.com/spiffe/spiffe/blob/master/ssc/README.md) that is exclusively responsible for SPIFFE's [standards](https://github.com/spiffe/spiffe/tree/master/standards) and the Project's strategic goals and direction. SSC members have final authority over:
 
 * Technical direction of the Project.
 * Project governance and process (this document).
 * Contribution policy.
 
-The TSC adheres to the following:
+The SSC adheres to the following:
 
-* The TSC meets the first Wednesday of each month ([Meeting Notes](https://docs.google.com/document/d/14Kttz1g-S-DdK0i_0JTjr8LDEImlSvCPT2qRSf6zGSY/edit) | [Calendar ICS](https://calendar.google.com/calendar/ical/scytale.io_k02mh5on54t6jjof5s6932ebgs%40group.calendar.google.com/public/basic.ics))
-* The TSC is comprised of at least five (5) members.
-* No more than 2 TSC members may be affiliated with the same organization.
-* At least 40% of the TSC must be represented by organizations that currently have a SPIFFE implementation deployed in production.
-* Each TSC member's term is nine (9) months.
-* There is no limit to the number of terms a TSC member can serve.
-* TSC members are added (or removed) by the consensus of the existing TSC members.
-* TSC members may remove themselves voluntarily at any time.
+* The SSC meets the first Wednesday of each month ([Meeting Notes](https://docs.google.com/document/d/14YlmMTqwqNdx-CWapwwIBMaakH5Z2UnAvOBQBB8AwQM) | [Calendar ICS](https://calendar.google.com/calendar/ical/c_gck7v87m9obq6n3hpo01l7csus%40group.calendar.google.com/public/basic.ics))
+* The SSC is comprised of at least five (5) members.
+* No more than 2 SSC members may be affiliated with the same organization.
+* At least 40% of the SSC must be represented by organizations that currently have a SPIFFE implementation deployed in production.
+* Each SSC member's term is 24 months.
+* There is no limit to the number of terms an SSC member can serve.
+* SSC members may remove themselves voluntarily at any time.
+
+For more information about the SSC, please refer to the [SSC Charter](ssc/CHARTER.md).
 
 ## Decision Making
 
-Maintainer and TSC decisions are made by a [lazy consensus](http://rave.apache.org/docs/governance/lazyConsensus.html) approach. When formal voting is required, members may abstain. Negative votes must be accompanied by an explanation or alternative proposal.
+Maintainer and SSC decisions are made by a [lazy consensus](http://rave.apache.org/docs/governance/lazyConsensus.html) approach. When formal voting is required, members may abstain. Negative votes must be accompanied by an explanation or alternative proposal.
 
 ## Change Review Process
 
-**All changes must be submitted as a Github Pull Request (PR)**
+**All changes must be submitted as a GitHub Pull Request (PR)**
 
-The submitter of a PR is responsible for responding to feedback from reviewers and maintainers. While the PR remains open, he or she is also responsible for ensuring the change is always in a state where it can be merged. Guidelines for submitting a PR for approval can be found [here](/CONTRIBUTING.md).
+The submitter of a PR is responsible for responding to feedback from reviewers and maintainers. While the PR remains open, they are also responsible for ensuring the change is always in a state where it can be merged. Guidelines for submitting a PR for approval can be found [here](/CONTRIBUTING.md).
 
 **All minor changes must be approved by at least one other Maintainer**
 

--- a/ssc/CHARTER.md
+++ b/ssc/CHARTER.md
@@ -1,0 +1,56 @@
+# SPIFFE Steering Committee Responsibilities and Charter
+The SPIFFE Steering Committee (or SSC) is a group of volunteers that oversee the strategic direction and growth of all projects falling under the SPIFFE umbrella. It is the only group that presides over the full spectrum of SPIFFE-related work - a posture necessary for SSC success. For our purposes, we define any software project residing in the `SPIFFE` GitHub organization as falling under the SPIFFE umbrella.
+
+This document defines the SSC mission and charter, as well as the responsibilities of members of the SSC.
+
+## Mission
+To ensure the long-term success of SPIFFE by providing leadership, guidance, and communication channels to SPIFFE project users, maintainers, and contributors.
+
+## Charter
+* Actively engage with the SPIFFE community (users, contributors, and maintainers) to ensure that their needs are being met
+* Curation of the scope and set of projects under the SPIFFE/SPIRE umbrella
+* Define, track, and publicize progress against yearly goals for the SPIFFE projects and community
+* Define, evolve, and promote the non-technical vision/mission and values of the SPIFFE projects
+* Define and evolve the SPIFFE project governance, SSC role and structure, and code of conduct as needed
+* Receive and handle reports about code of conduct violations and maintain confidentiality
+* Act as the final escalation point and decider for any disputes or issues within the SPIFFE projects
+
+## SSC Member Responsibilities
+* Act as SPIFFE project ambassadors both within the cloud native community and the industry at large
+* Be generally available for SPIFFE community members, maintainers, and contributors
+* Attend all SSC calls and meetings
+* Faithfully uphold the SSC charter, acting in the best interest of the SPIFFE projects
+* Abide by the SPIFFE and CNCF Code of Conduct
+
+## SSC Seat Election and Term
+The SSC comprises five seats, each of which carry a two year term. All seats are equal in their capacity and requirements. Terms are staggered to avoid a majority churn in any one election cycle.
+
+SSC seats are assigned to individuals and not companies. Incumbents retain their SSC membership in the event that their affiliation changes. If the affiliation change results in a violation of the corporate diversity policy as defined by the SPIFFE project governance, then a vacancy shall be forced. All incumbents must disclose their affiliation.
+
+### Election and Term Mechanics
+Elections shall take place once every six months. SPIFFE community members and contributors demonstrating active engagement in the project(s) are invited to both nominate and vote on new SSC members. For the purpose of SSC seat nomination and election, active engagement is defined as:
+* Any individual that has opened a GitHub Issue or PR against a SPIFFE project in the last 12 months
+* Any individual holding an official project seat (e.g. project maintainers) at the time of the election
+* Any individual that has attended the majority of calls held for any given Special Interest Group (SIG) in the last 6 months
+
+The definition of active engagement is purposefully a loose one, and it is recognized that the bar may be met without adhering to the spirit of the rule. As such, individuals who meet the requirements in letter but not in spirit may, at the discretion of the SSC, not be invited to nominate or vote in any given election.
+
+Conversely, it is also recognized that the stated definition is not perfect, and that there may be individuals with contributions to the community and/or projects that do not meet these requirements. The SSC is happy to consider such cases, and will make exceptions when fit. Please email ssc@spiffe.io for more information.
+
+Each voting community member may choose up to two nominees per seat, and cast one ranked vote. The process to elect a new seat is as follows:
+* 21 days prior to election: a call for nominations is distributed to each voting community member
+* 14 days prior to election: call for nominations close
+* 7 days prior to election: a ballot is distributed to each voting community member
+* 0 days prior to election: ballots are counted, and results announced
+
+### Nominee Qualification
+SSC nominees must meet a minimum set of qualifications before they're eligible to appear on the election ballot. Each nominee will be evaluated by the existing SSC members for eligibility, wherein a nominee must receive support from a majority of the SSC to be considered eligible. Prior to ballot distribution, nominees will be contacted by an SSC member (or a representative thereof) to discuss the qualification criteria and ensure that the nominee is willing to serve a full term. The SSC nominee qualification criteria are as follows:
+* Nominee must commit that they have the available bandwidth to make the time to invest in the SSC and carry out their duties
+* Nominee must be able to operate neutrally in discussions and put the goals and success of the SPIFFE projects in balance with the interests of any affiliation they may carry
+* Nominee must thoroughly understand the problem space and the goals of the SPIFFE project
+* Nominee must demonstrate experience and seniority sufficient to access additional staff or community members to assist in their SSC preparations
+
+There is no term limit. Existing SSC members are eligible for nomination and re-election at the end of their term.
+
+### SSC Right to Amend
+The election process described in this document is intended to meet the needs of the SPIFFE project and community in a way that is concise and lightweight. It is not intended to be a legal document in which every eventuality is accounted for - project and community members are expected to act in good faith. As such, the SSC reserves the right to modify or alter this process, as they see fit and through a majority vote, in response to any perceived abuse.

--- a/ssc/README.md
+++ b/ssc/README.md
@@ -1,0 +1,27 @@
+# The SPIFFE Steering Committee
+The SPIFFE Steering Committee (or SSC) is a group of volunteers that oversee the strategic direction and growth of all projects falling under the SPIFFE umbrella. It is the only group that presides over the full spectrum of SPIFFE-related work.
+
+Please read the [SSC Charter](CHARTER.md) for more information about the SSC's role and mission.
+
+## SSC Members
+The current members of the SSC, ordered by term,  are as follows:
+
+**Mark Lakewood** (@mlakewood)  
+[GitHub](https://github.com/mlakewood) | [LinkedIn](https://www.linkedin.com/in/marklakewood)  
+Term end: May 5th, 2021
+
+**Jon Debonis** (@jondb)  
+[GitHub](https://github.com/jondb) | [LinkedIn](https://www.linkedin.com/in/jondb)  
+Term end: May 5th, 2021  
+
+**Joe Beda** (@jbeda)  
+[GitHub](https://github.com/jbeda) | [LinkedIn](https://www.linkedin.com/in/jbeda)  
+Term end: November 3rd, 2021  
+
+**Emiliano Berenbaum** (@y2bishop2y)  
+[GitHub](https://github.com/y2bishop2y) | [LinkedIn](https://www.linkedin.com/in/eberenb)  
+Term end: November 3rd, 2021  
+
+**Evan Gilman** (@evan2645)  
+[GitHub](https://github.com/evan2645) | [LinkedIn](https://www.linkedin.com/in/evan2645)  
+Term end: May 4th, 2022  


### PR DESCRIPTION
The SSC, formerly known as the TSC, has recently revamped their charter
to better reflect the needs of the projects. The new charter was
developed over a series of public calls, in cooperation with SPIFFE
project maintainers. This commit ports the working version out of Google
Docs and into Markdown. The original version can be found here: https://docs.google.com/document/d/1OvNBn9s3WBegbgOPUu-YMUzbgzk-CjSR2Gk4-XPgvfk

This commit also updates the CODEOWNERS file to better reflect reality.
A new `ssc` GitHub group will be kept up-to-date, and some files in this
repository are managed by them (vs SPIFFE maintainers).

Finally, the project governance document has been updated to reflect the
new charter and naming.

Please note that the governance document is in need of further update,
however that is out of scope for this change.

Signed-off-by: Evan Gilman <egilman@vmware.com>