### PR TITLE
Add SSC election scaffolding

### DIFF
--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -36,7 +36,7 @@ If you'd like to nominate an SSC member for this election cycle, please follow t
 ### Electing an SSC Member
 The SPIFFE project uses the [CIVS](https://civs.cs.cornell.edu/) tool to conduct its elections. Once the polls open, all eligible participants will receive an email from this tool. The email includes a link which can be used to vote. Do not share this link, as it is private.
 
-If you ar in the list of eligible participants, and you don't receive a link on the day the polls open, please contact the SSC at ssc@spiffe.io.
+If you are in the list of eligible participants, and you don't receive a link on the day the polls open, please contact the SSC at ssc@spiffe.io.
 
 Each participant casts a single ranked vote. If more than one SSC seat is available, the top N nominees will be selected.
 

--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+# YYYY [H1,H2] SSC Election
+This is the official tracking issue for the YYYY [H1,H2] SSC election. The timeline for this election is as follows:
+* MONTH DAY, YEAR: Nominations open
+* MONTH DAY, YEAR: Nominations close
+* MONTH DAY, YEAR: Polls open
+* MONTH DAY, YEAR: Polls close
+* MONTH DAY, YEAR: Results announced
+
+## How to Participate
+All SPIFFE community members and contributors demonstrating active engagement in the project(s) are invited to both nominate and vote on new SSC members. The eligible participants are listed below. For more information about the definition of active engagement, and how this list was compiled, please see the Election and Term Mechanics section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#election-and-term-mechanics).
+
+All eligible participants MUST have an email address publicly associated with their GitHub account. You may be omitted from the participant list if we're unable to determine your email address.
+
+If you feel that you are an active SPIFFE community member or contributor but are not included in the list below, please contact the SSC at ssc@spiffe.io and we will be happy to include you.
+
+### Nominating an SSC Member
+Eligible participants may nominate up to two candidates per available SSC seat during the nomination period. They may nominate themselves or someone else.
+
+If you'd like to nominate an SSC member for this election cycle, please follow these steps:
+1. Verify that your GitHub handle is included in the list of eligible participants below
+1. Verify that, in your best judgement, the nominee meets the criteria specified in the Nominee Qulifications section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#nominee-qualification)
+1. Fork this repository
+1. Copy `ssc/elections/NOMINEE_TEMPLATE.md` into the appropriate subdirectory, and name it after the person to be nominated
+	1. For example, from the root directory:  
+	```
+	$ cp ssc/elections/NOMINEE_TEMPLATE.md ssc/elections/2021H1/JANE_DOE.md
+	```  
+1. Fill in all fields in the copied template as completely as possible
+1. Open a GitHub Pull Request back to this repository to add the new nominee
+	1. Create a new commit with the name of the election and nominee
+		1. For example, `Nominate Jane Doe for 2021H1 SSC Election`
+	1. Open a new GitHub Pull Request against https://github.com/spiffe/spiffe
+		1. Give the Pull Request the same name as the commit it includes
+1. An SSC member will review the nomination and merge it when ready
+
+### Electing an SSC Member
+The SPIFFE project uses the [CIVS](https://civs.cs.cornell.edu/) tool to conduct its elections. Once the polls open, all eligible participants will receive an email from this tool. The email includes a link which can be used to vote. Do not share this link, as it is private.
+
+If you ar in the list of eligible participants, and you don't receive a link on the day the polls open, please contact the SSC at ssc@spiffe.io.
+
+Each participant casts a single ranked vote. If more than one SSC seat is available, the top N nominees will be selected.
+
+## Eligible Participants
+This section lists everyone eligible to participate in this SSC election cycle. If you believe you were omitted in error, please contact the SSC at ssc@spiffe.io.
+
+* LAST\_NAME, FIRST\_NAME (@GITHUB\_HANDLE) \<EMAIL\_ADDRESS\>
+* ...

--- a/ssc/elections/ELECTION_README_TEMPLATE.md
+++ b/ssc/elections/ELECTION_README_TEMPLATE.md
@@ -1,0 +1,12 @@
+# YYYY [H1,H2] SSC Election
+This subdirectory captures the nominees and results of the YYYY [H1,H2] SSC election. The timeline for this election is as follows:
+* MONTH DAY, YEAR: Nominations open
+* MONTH DAY, YEAR: Nominations close
+* MONTH DAY, YEAR: Polls open
+* MONTH DAY, YEAR: Polls close
+* MONTH DAY, YEAR: Results announced
+
+For more information on how to participate, please see the relevant GitHub [tracking issue](LINK_TO_ISSUE).
+
+## Results
+To be announced.

--- a/ssc/elections/NOMINEE_TEMPLATE.md
+++ b/ssc/elections/NOMINEE_TEMPLATE.md
@@ -1,0 +1,8 @@
+# NOMINEE NAME HERE
+A brief biography of the nominee goes here. What is their background? How does their work relate to SPIFFE and/or why is SPIFFE important to them? What about them makes them a good fit for the SSC? This information is very important and will be heavily considered by voters in order to make an informed decision.
+
+Be sure to preserve the two empty spaces at the end of each line below.  
+**GitHub Handle:** @NOMINEE\_GITHUB\_HANDLE\_HERE  
+**Email Address:** NOMINEE\_EMAIL\_ADDRESS\_HERE  
+**LinkedIn Profile:** LINK\_TO\_NOMINEE\_LINKEDIN\_HERE  
+**Current Affiliation:** NOMINEE\_AFFILIATION\_HERE  

--- a/ssc/elections/README.md
+++ b/ssc/elections/README.md
@@ -1,0 +1,64 @@
+# SSC Elections
+Welcome to the SSC elections. Here you will find information about how SSC elections are conducted, as well as past and current SSC elections.
+
+For information about a specific election, please see the relevant subdirectory.
+
+## SSC Election Process
+Each SSC election has a dedicated subdirectory and tracking issue in this repository. The tracking issue can be subscribed to by interested parties, and will be updated as the election progresses.
+
+All nominees are proposed via GitHub Pull Request, and each nominee gets a dedicated file in the relevant subdirectory (e.g. `2021H1` for the first election of 2021). A list of eligible participants, as well as detailed instructions on how to participate in the election process, are documented in the subdirectory's README.
+
+The rest of this section captures the exact steps necessary to begin and complete an SSC election. These steps are to be performed by an SSC member, or appointed party.
+
+### T-28 Days: Preparation
+1. Identify eligible participants
+	1. Eligible participants MUST have a public email address on their GitHub profile
+1. Open GitHub issue to track election
+	1. The title should be `YYYY [H1,H2] SSC Election`
+	1. Use the text in `ELECTION_ISSUE_TEMPLATE.md` as the issue body, filling in the details as needed
+1. Announce the start of a new election cycle
+	1. Slack #announcements channel
+	1. SIG mailing lists
+
+### T-21 Days: Nomination Opens
+1. Create the election directory (e.g. `ssc/elections/2021H1`)
+	1. Copy in `ELECTION_README_TEMPLATE.md`, renaming to `README.md`
+		1. Fill in details, as appropriate
+	1. Send a PR titled `Open Nominations for YYYY [H1,H2] SSC Election` to add the new directory and README
+	1. Once merged, comment on the tracking issue to announce that nominations are now open
+1. All nomination PRs are to be left OPEN during the nomination period
+	1. GH reactions and comments are welcome
+1. Announce the start of nominations
+	1. Slack #announcements channel
+	1. SIG mailing lists
+
+### T-14 Days: Nomination Closes
+1. Comment on tracking issue that nominations are now closed
+1. SSC members perform due diligence on all nominations
+	1. Each SSC member to take a portion of the nominations
+	1. SSC members to initiate nominee-specific private SSC discussion if concern about qualification arises
+	1. For every qualified nominee, SSC member performing due diligence to merge nomination PR
+
+### T-7 Days: Polling Opens
+1. One SSC member to volunteer as election supervisor
+	1. Election supervisor opens poll on [CIVS](https://civs.cs.cornell.edu/)
+1. Comment on tracking issue that polls are now open
+	1. All eligible participants should have received an email
+1. Announce that the polls are now open
+	1. Slack #announcements channel
+	1. SIG mailing lists
+
+### T-0 Days: Polling Closes and Results Announced
+1. Election supervisor closes [CIVS](https://civs.cs.cornell.edu/) poll
+1. Comment on tracking issue that polls are now closed
+1. Share full poll results privately with SSC
+	1. Check for signs of abuse
+1. Send a PR to add results to the election's README
+	1. Only the new seats are to be named in the results section
+1. Comment on tracking issue with the results
+	1. Link to PR
+	1. Tracking issue to be closed once PR is merged
+1. Announce results
+	1. Slack #announcements channel
+	1. SIG mailing lists
+


### PR DESCRIPTION
This commit adds all the documentation and directory structure required
to run SSC elections. Included are READMEs, TEMPLATEs, which include
instructions on how to operate and participate in an SSC election.

Since this is our first election, the process may be tweaked here or
there as we run through it. This commit puts the first stake in the
ground.

Signed-off-by: Evan Gilman <egilman@vmware.com>