### PR TITLE
Update stale references to SPIFFE TSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Most community activity is organized into Special Interest Groups (SIGs), time-b
 
 **Follow the SPIFFE Project** You can find us on [Github](https://github.com/spiffe/) and [Twitter](https://twitter.com/SPIFFEio).
 
-## SPIFFE TSC
-The SPIFFE [Technical Steering Committee](/GOVERNANCE.md#technical-steering-committee-tsc) meets on a regular cadence to review project progress, address maintainer needs, and provide feedback on strategic direction and industry trends. Community members interested in joining this call can find details below.
+## SPIFFE SSC
+The [SPIFFE Steering Committee](/GOVERNANCE.md#the-spiffe-steering-committee-ssc) meets on a regular cadence to review project progress, address maintainer needs, and provide feedback on strategic direction and industry trends. Community members interested in joining this call can find details below.
 
 * Calendar: [iCal](https://calendar.google.com/calendar/ical/c_gck7v87m9obq6n3hpo01l7csus%40group.calendar.google.com/public/basic.ics) or [Browser-based](https://calendar.google.com/calendar/embed?src=c_gck7v87m9obq6n3hpo01l7csus%40group.calendar.google.com&ctz=America%2FChicago)
 * Meeting Notes: [Google Doc](https://docs.google.com/document/d/14YlmMTqwqNdx-CWapwwIBMaakH5Z2UnAvOBQBB8AwQM)
 * Call Details: [Zoom Link](https://zoom.us/j/95959131216?pwd=akw4RzlEUEVCTnFkWE5KdWFPZXpkdz09)
 
-To contact the TSC privately, please send an email to [tsc@spiffe.io](mailto:tsc@spiffe.io).
+To contact the SSC privately, please send an email to [ssc@spiffe.io](mailto:ssc@spiffe.io).

--- a/community/sig-community/README.md
+++ b/community/sig-community/README.md
@@ -22,7 +22,7 @@ A Special Interest Group (SIG) concerning the nurture and growth of the SPIFFE c
   * Support inclusivity and diversity of the SPIFFE/SPIRE community
 
 ### Non-Goals:
-* Code of Conduct oversight (Please contact the [SPIFFE TSC](https://github.com/spiffe/spiffe#spiffe-tsc) for this purpose)
+* Code of Conduct oversight (Please contact the [SSC](https://github.com/spiffe/spiffe#spiffe-ssc) for this purpose)
 * SPIFFE/SPIRE roadmap, feature, or issue consideration
 
 ### Leads:


### PR DESCRIPTION
This commit updates some stale references I missed to SPIFFE TSC

s/TSC/SSC/g

Signed-off-by: Evan Gilman <egilman@vmware.com>