### PR TITLE
Add election directory for 2021 H1

### DIFF
--- a/ssc/elections/2021H1/ELECTION_README.md
+++ b/ssc/elections/2021H1/ELECTION_README.md
@@ -1,0 +1,12 @@
+# 2021 H1 SSC Election
+This subdirectory captures the nominees and results of the 2021 H1 SSC election. The timeline for this election is as follows:
+* April 14, 2021: Nominations open
+* April 21, 2021: Nominations close
+* April 27, 2021: Polls open
+* May 4, 2021: Polls close
+* May 5, 2021: Results announced
+
+For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/160).
+
+## Results
+To be announced.


### PR DESCRIPTION
This PR adds the required directory for 2021 H1 SSC elections. Once this is merged, we will be able to open nominations.

Signed-off-by: Evan Gilman <egilman@vmware.com>