### PR TITLE
Nominate Andrew Jessup for 2021H1 SSC Election

### DIFF
--- a/ssc/elections/2021H1/Andrew_Jessup.md
+++ b/ssc/elections/2021H1/Andrew_Jessup.md
@@ -1,0 +1,7 @@
+# Andrew Jessup
+Andrew has been a champion for SPIFFE since its practical inception. Drawing on his previous experience as an engineer and product manager at Google and elsewhere, Andrew has been instrumental in helping to breathe life into SPIFFE in its early days. He understands the landscape well, and is a strong user advocate with focus on usability and totality. Should he accept this nomination, I think he'd bring a wealth of value and perspective to the SSC.
+
+**GitHub Handle:** @ajessup  
+**Email Address:** ajessup@gmail.com  
+**LinkedIn Profile:** https://www.linkedin.com/in/andrewjessup/  
+**Current Affiliation:** HPE  


### PR DESCRIPTION
Signed-off-by: Evan Gilman <egilman@vmware.com>