### PR TITLE
Nominate Wei Fu for 2021H1 SSC Election

### DIFF
--- a/ssc/elections/2021H1/LEE_ERIC
+++ b/ssc/elections/2021H1/LEE_ERIC
@@ -1,0 +1,7 @@
+Eric Lee is Site Reliability Engineer at GitHub. In his role, he is responsible for making SPIFFE and SPIRE available to engineers at GitHub. Eric understands the ins and outs of going from idea to production, as well as deep understanding of the challenges of making SPIFFE available to multiple teams once in production. As such, he has a good grasp on the pains and needs of prospective adopters and end users alike. Additionally, he has been a long time supporter and evangelist of the projects. His personal style is characterized for his pragmatism - he is a great asset whenever dealing with problems or tough conversations that require decision making.  
+
+
+GitHub Handle: @elee  
+Email Address: elee@github.com  
+LinkedIn Profile: https://www.linkedin.com/in/elee1/  
+Current Affiliation: GitHub.   

--- a/ssc/elections/Nominate Wei Fu for 2021H1 SSC Election
+++ b/ssc/elections/Nominate Wei Fu for 2021H1 SSC Election
@@ -1,0 +1,6 @@
+Wei Fu is engineering manager at Uber with over a decade’s worth experience in the architecture, design, coding and testing of identity software solutions. In her job, she is responsible for overseeing the operation and delivery of one of the largest known SPIRE deployments. She possesses a unique perspective that blends the practical understanding that comes from operating SPIRE at the edge of scale and performance, combined with the responsibility of delivering that same technology in service of a global e-commerce business. On top of that, she is known for her relentless focus and is a demonstrated leader in bringing others along on the SPIFFE journey. 
+
+GitHub Handle: @wfu  
+Email Address: wei.fu@uber.com  
+LinkedIn Profile: https://www.linkedin.com/in/fu-wei/  
+Current Affiliation: Uber Technologies, Inc  


### PR DESCRIPTION
Nominate Wei Fu for 2021H1 SSC Election

Signed-off-by: Andres Vega <andresv@vmware.com>