### PR TITLE
Record 2021 H1 SSC Election Results

### DIFF
--- a/ssc/README.md
+++ b/ssc/README.md
@@ -25,3 +25,11 @@ Term end: November 3rd, 2021
 **Evan Gilman** (@evan2645)  
 [GitHub](https://github.com/evan2645) | [LinkedIn](https://www.linkedin.com/in/evan2645)  
 Term end: May 4th, 2022  
+
+**Andrew Jessup** (@ajessup)
+[GitHub](https://github.com/ajessup) | [LinkedIn](https://www.linkedin.com/in/andrewjessup/)
+Term end: May 3rd, 2023
+
+**Frederick Kautz** (@fkautz)
+[GitHub](https://github.com/fkautz) | [LinkedIn](https://www.linkedin.com/in/fkautz/)
+Term end: May 3rd, 2023

--- a/ssc/elections/2021H1/README.md
+++ b/ssc/elections/2021H1/README.md
@@ -17,4 +17,5 @@ For more information on how to participate, please see the relevant GitHub [trac
 * [Andrew Moore](ANDREW_MOORE.md)
 
 ## Results
-To be announced.
+* [Andrew Jessup](ANDREW_JESSUP.md)
+* [Frederick Kautz](FREDERICK_KAUTZ.md)


### PR DESCRIPTION
Welcome to @ajessup and @fkautz as the newest SSC members, who will be replacing Jon Debonis and Mark Lakewood. Thank you to Jon and Mark for all your help over the years!

This concludes the 2021 H1 election cycle tracked in https://github.com/spiffe/spiffe/issues/160

Signed-off-by: Evan Gilman <egilman@vmware.com>