### PR TITLE
Reconcile contradiction between ValidateJWTSVID gRPC definition and spec

### DIFF
--- a/standards/SPIFFE_Workload_API.md
+++ b/standards/SPIFFE_Workload_API.md
@@ -349,7 +349,9 @@ As mentioned in [Stream Responses](#42-stream-responses), each `JWTBundleRespons
 
 The `ValidateJWTSVID` RPC validates JWT-SVIDs for a specific audience on behalf of a client.
 
-All fields in the `ValidateJWTSVIDRequest` and `ValidateJWTSVIDResponse` message are mandatory.
+All fields in the `ValidateJWTSVIDRequest` request message are mandatory.
+
+The `ValidateJWTSVIDResponse` response message consists of a mandatory `spiffe_id` field, which MUST contain the SPIFFE ID of the validated JWT-SVID. The `claims` field is optional.
 
 ### 6.3 JWT-SVID Validation
 


### PR DESCRIPTION
The comments in the gRPC definition of ValidateJWTSVID declare the
ValidateJWTSVIDResponse.claims field to be optional, but the
specification text indicates that all fields in ValidateJWTSVIDResponse
are required. These two statements contradict one another.

Updating the text in the specification to match the comment in the gRPC
definition of ValidateJWTSVID using similar language to descriptions of
other Workload API request/response message types.