### PR TITLE
Add SPIRE Contributor sync meeting to SIG-SPIRE description

### DIFF
--- a/community/sig-spire/README.md
+++ b/community/sig-spire/README.md
@@ -3,22 +3,36 @@
 A Special Interest Group (SIG) concerning SPIRE, the official SPIFFE implementation.
 
 ### Meetings:
+* [Calendar ICS](https://calendar.google.com/calendar/ical/c_q2don6m2b33gljqftauib3hnuk%40group.calendar.google.com/public/basic.ics)
+
+#### SIG-SPIRE
 * Date/Time: Every other Thursday @ 10:30am Pacific
 * [Meetings Notes](https://docs.google.com/document/d/1IgpCkvSRSoY9Xd16gFQJJ1KP8sLZ7EE39cEjBK_UIg4)
-* [Calendar ICS](https://calendar.google.com/calendar/ical/c_q2don6m2b33gljqftauib3hnuk%40group.calendar.google.com/public/basic.ics)
+
+##### Goals:
+* Discuss SPIRE project direction and roadmap
+* Provide a high-bandwidth forum in which the community can voice needs and make proposals
+* Achieve maintainer consensus on architectural decisions related to major SPIRE features
+
+##### Non-Goals:
+* Day to day SPIRE maintenance
+* Troubleshooting
+
+#### SPIRE Contributor Sync
+* Date/Time: Every Tuesday @ 11:30am Pacific
+
+##### Goals:
+* Discuss design and implementation of current SPIRE development efforts
+* Receive feedback and direction from maintainers on proposed code changes
+
+##### Non-Goals:
+* Discuss larger architectural changes to SPIRE
+* User support and troubleshooting
 
 ### Contact:
 * [Slack Channel](https://spiffe.slack.com/messages/spire/)
 * [Google Group](https://groups.google.com/a/spiffe.io/d/forum/sig-spire)
 
-### Goals:
-* Discuss SPIRE project direction and roadmap
-* Provide a high-bandwidth forum in which the community can voice needs and make proposals
-* Achieve maintainer consensus on architectural decisions related to major SPIRE features
-
-### Non-Goals:
-* Day to day SPIRE maintenance
-* Troubleshooting
 
 ### Lead:
 * Daniel Feldman ([GitHub](https://github.com/dfeldman) / [LinkedIn](https://www.linkedin.com/in/dfeldman/))


### PR DESCRIPTION
The SPIRE Contributor sync meeting has been ongoing for several months
and is used as a forum for contributors to meet with SPIRE maintainers
to get feedback and direction on currently proposed code changes to the
project. Mentioning the existence of the meeting here to more clearly
advertise it to current and future contributors to SPIRE.