### PR TITLE
Add SPIFFE maturity phases

### DIFF
--- a/MATURITY.md
+++ b/MATURITY.md
@@ -5,7 +5,7 @@ This document provides detailed information about the maturity phases of the var
 
 The SPIFFE project maintains three phases of maturity which indicate the level of reliability and scale at which a particular project or sub-project is known to support:
 - **Development**: The software is still under active development, and many efforts are exploratory. APIs and interfaces may change rapidly and without warning. Use this software for development and proof of concept purposes, but stability and longevity is not guaranteed.
-- **Pre-Production**: The software is relatively stable and being used to solve real problems. APIs and interfaces may change, but effort will be made to consider comptability. Use this software for integration investigation and technology evaluation. Some early adopters may choose to run this software in production, however it is not recommended. Deprecation of this software is unlikely.
+- **Pre-Production**: The software is relatively stable and being used to solve real problems. APIs and interfaces may change, but effort will be made to consider compatibility. Use this software for integration investigation and technology evaluation. Some early adopters may choose to run this software in production, however it is not recommended. Deprecation of this software is unlikely.
 - **Production**: The software is stable and being used in production at scale. APIs and interfaces have compatibility guarantees. Use of this software is safe for mission critical purposes. Deprecation of this software will be performed on a years-long time scale.
 - **Deprecated**: The software is no longer maintained, and may or may not continue to fill its intended purpose. While API stability is assumed due to lack of development, compatibility with other components is not guaranteed and likely to break in due time. Use of this software is not recommended.
 
@@ -48,7 +48,7 @@ Characteristics of software in the **Pre-Production** phase:
 - Software has been fully documented and includes:
   - A clear indication that it is in the **Pre-Production** phase
   - Supported versions of relevant components (e.g. supported SPIRE versions, etc)
-  - Kown limitations
+  - Known limitations
   - Basic troubleshooting
   - API documentation
 
@@ -69,8 +69,8 @@ Characteristics of software in the **Production** phase:
 - A security policy and response process is clearly defined and includes:
   - Acknowledgement time of less than seven days
 - ADOPTERS.md file is present
-- Software documentaiton is complete and includes:
-  - A clear indication that it is in the **Production**
+- Software documentation is complete and includes:
+  - A clear indication that it is in the **Production** phase
   - Working examples exercised by automated test suites
   - Known bugs
   - Comprehensive troubleshooting guide(s)
@@ -85,6 +85,7 @@ Software in the **Deprecated** phase is no longer actively developed. Emergency 
 ### Characteristics
 Characteristics of software in the **Deprecated** phase:
 
+- A clear indication in the documentation that it is in the **Deprecated** phase
 - Apache 2 licensed
 - Zero velocity
 - Not tested or exercised in any official capacity

--- a/MATURITY.md
+++ b/MATURITY.md
@@ -1,0 +1,91 @@
+# SPIFFE Project Maturity Phases
+SPIFFE comprises a handful of software projects, all of which share a common governance structure. As these projects may vary in their respective levels of maturity, it is important for SPIFFE/SPIRE users to have a strong sense of what to expect prior to adopting or deploying them.
+
+This document provides detailed information about the maturity phases of the various projects that are part of the overarching [SPIFFE project](https://github.com/spiffe).
+
+The SPIFFE project maintains three phases of maturity which indicate the level of reliability and scale at which a particular project or sub-project is known to support:
+- **Development**: The software is still under active development, and many efforts are exploratory. APIs and interfaces may change rapidly and without warning. Use this software for development and proof of concept purposes, but stability and longevity is not guaranteed.
+- **Pre-Production**: The software is relatively stable and being used to solve real problems. APIs and interfaces may change, but effort will be made to consider comptability. Use this software for integration investigation and technology evaluation. Some early adopters may choose to run this software in production, however it is not recommended. Deprecation of this software is unlikely.
+- **Production**: The software is stable and being used in production at scale. APIs and interfaces have compatibility guarantees. Use of this software is safe for mission critical purposes. Deprecation of this software will be performed on a years-long time scale.
+- **Deprecated**: The software is no longer maintained, and may or may not continue to fill its intended purpose. While API stability is assumed due to lack of development, compatibility with other components is not guaranteed and likely to break in due time. Use of this software is not recommended.
+
+---
+
+## Development
+
+### Description
+Software in the **Development** phase is being actively developed by the SPIFFE community, and is still in its infancy. The primary audience of this software is developers and technology enthusiasts.
+
+### Characteristics
+Characteristics of software in the Development phase:
+
+- Apache 2 licensed
+- Rapidly evolving (days-to-weeks)
+- No compatibility guarantee (or by extension, upgrade guarantee)
+- Supported by developers actively working on the software
+- Basic documentation (e.g. a README.md file) has been written, and includes:
+  - A clear indication that it is in the **Development** phase
+  - Description of its covered use cases
+  - Supported versions of relevant components (e.g. supported SPIRE versions, etc)
+  - Known limitations
+
+## Pre-Production
+
+### Description
+Software in the **Pre-Production** phase is still under active development by the SPIFFE community, but is relatively stable and has entered into a more mature phase than software still in the **Development** phase.
+
+### Characteristics
+Characteristics of software in the **Pre-Production** phase:
+
+- Apache 2 licensed
+- Moderate velocity (weeks-to-month)
+- Best effort compatibility guarantee
+- A comprehensive set of examples is available
+- Automated test suites are exercised regularly
+- Pre-built artifacts are published and made publicly available
+- Supported by both developers and early adopter community
+- A security policy is clearly defined (i.e. SECURITY.md)
+- Software has been fully documented and includes:
+  - A clear indication that it is in the **Pre-Production** phase
+  - Supported versions of relevant components (e.g. supported SPIRE versions, etc)
+  - Kown limitations
+  - Basic troubleshooting
+  - API documentation
+
+## Production
+
+### Description
+Software in the **Production** phase is stable and actively maintained. It can be relied upon to operate in production and at scale.
+
+### Characteristics
+Characteristics of software in the **Production** phase:
+
+- Apache 2 licensed
+- Moderate to low velocity (month-to-months)
+- Well tested via unit, functional, and integration test suites on multiple platforms (when applicable)
+- Strict compatibility guarantees are in place and upgrade/compatibility guidance is published
+- Pre-built artifacts are published by an automated system for multiple platforms (when applicable)
+- Supported by maintainers and a broad community of adopters
+- A security policy and response process is clearly defined and includes:
+  - Acknowledgement time of less than seven days
+- ADOPTERS.md file is present
+- Software documentaiton is complete and includes:
+  - A clear indication that it is in the **Production**
+  - Working examples exercised by automated test suites
+  - Known bugs
+  - Comprehensive troubleshooting guide(s)
+  - Complete API documentation
+  - Architecture and deployment guidelines
+
+## Deprecated
+
+### Description
+Software in the **Deprecated** phase is no longer actively developed. Emergency releases may occur in response to security issues on a case-by-case basis, however such maintenance should not be expected. Do not adopt this software.
+
+### Characteristics
+Characteristics of software in the **Deprecated** phase:
+
+- Apache 2 licensed
+- Zero velocity
+- Not tested or exercised in any official capacity
+- Likely to be removed from GitHub in the near future


### PR DESCRIPTION
This commit adds a document that describes the maturity phases of SPIFFE
projects. As SPIFFE grows, and so does the number of (sub)projects,
clearly communicating to our users the maturity level of the software in
question is very important in maintaining user trust.

As discussed in the June SSC call.

Just about everything in this document is up for discussion, including the
terminology and names of the phases. Any/all feedback welcome.

Signed-off-by: Evan Gilman <egilman@vmware.com>