### PR TITLE
Open nominations for 2021 H2 SSC election

### DIFF
--- a/ssc/elections/2021H2/README.md
+++ b/ssc/elections/2021H2/README.md
@@ -1,0 +1,15 @@
+# 2021 H2 SSC Election
+This subdirectory captures the nominees and results of the 2021 H2 SSC election. The timeline for this election is as follows:
+* Oct 6, 2021: Nominations open
+* Oct 13, 2021: Nominations close
+* Oct 20, 2021: Polls open
+* Oct 27, 2021: Polls close
+* Nov 1, 2021: Results announced
+
+For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/194).
+
+## Nominations
+To be announced.
+
+## Results
+To be announced.

--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ All SPIFFE community members and contributors demonstrating active engagement in
 
 All eligible participants MUST have an email address publicly associated with their GitHub account. You may be omitted from the participant list if we're unable to determine your email address.
 
-If you feel that you are an active SPIFFE community member or contributor but are not included in the list below, please contact the SSC at ssc@spiffe.io and we will be happy to include you.
+If you feel that you are an active SPIFFE community member or contributor but are not included in the list below, please contact the SSC at ssc-elections@spiffe.io and we will be happy to include you.
 
 ### Nominating an SSC Member
 Eligible participants may nominate up to two candidates per available SSC seat during the nomination period. They may nominate themselves or someone else.
@@ -36,12 +36,18 @@ If you'd like to nominate an SSC member for this election cycle, please follow t
 ### Electing an SSC Member
 The SPIFFE project uses the [CIVS](https://civs.cs.cornell.edu/) tool to conduct its elections. Once the polls open, all eligible participants will receive an email from this tool. The email includes a link which can be used to vote. Do not share this link, as it is private.
 
-If you are in the list of eligible participants, and you don't receive a link on the day the polls open, please contact the SSC at ssc@spiffe.io.
+If you are in the list of eligible participants, and you don't receive a link on the day the polls open, please contact the SSC at ssc-elections@spiffe.io.
 
 Each participant casts a single ranked vote. If more than one SSC seat is available, the top N nominees will be selected.
 
 ## Eligible Participants
-This section lists everyone eligible to participate in this SSC election cycle. If you believe you were omitted in error, please contact the SSC at ssc@spiffe.io.
+This section lists everyone eligible to participate in this SSC election cycle. If you believe you were omitted in error, please contact the SSC at ssc-elections@spiffe.io.
 
 * LAST\_NAME, FIRST\_NAME (@GITHUB\_HANDLE) \<EMAIL\_ADDRESS\>
+* ...
+
+### Eligible Participants with Missing Email Addresses
+The following participants would normally be eligible to participate, but do not have email addresses published on their GitHub account. Please publish an email address and contact the SSC at ssc-elections@spiffe.io to be added to the list of eligible participants.
+
+* @GITHUB\_HANDLE
 * ...

--- a/ssc/elections/ELECTION_README_TEMPLATE.md
+++ b/ssc/elections/ELECTION_README_TEMPLATE.md
@@ -8,5 +8,8 @@ This subdirectory captures the nominees and results of the YYYY [H1,H2] SSC elec
 
 For more information on how to participate, please see the relevant GitHub [tracking issue](LINK_TO_ISSUE).
 
+## Nominees
+To be announced.
+
 ## Results
 To be announced.


### PR DESCRIPTION
This commit add the directory necessary for opening the 2021 H2 SSC election cycle. It also corrects the SSC elections email address in a couple of the related templates.

Signed-off-by: Evan Gilman <egilman@vmware.com>