### PR TITLE
Make the JWT-SVID schema spec conformant

### DIFF
--- a/standards/JWT-SVID.schema
+++ b/standards/JWT-SVID.schema
@@ -9,15 +9,9 @@ properties:
       alg:
         type: "string"
         description: |
-          The alg (algorithm) Header Parameter identifies the cryptographic
-          algorithm used to secure the JWS.  The JWS Signature value is not
-          valid if the alg value does not represent a supported algorithm or
-          if there is not a key for use with that algorithm associated with the
-          party that digitally signed or MACed the content. The alg value is a case-
-          sensitive ASCII string containing a StringOrURI value. This Header
-          Parameter MUST be present and MUST be understood and processed by
-          implementations.
-          see https://tools.ietf.org/html/rfc7515#section-4.1.1
+          The alg (algorithm) Header Parameter as defined in RFC 7518.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#21-algorithm for the supported values for JWT-SVIDs.
+          This Header Parameter is REQUIRED.
         enum:
           - "RS256"
           - "RS384"
@@ -25,18 +19,24 @@ properties:
           - "ES256"
           - "ES384"
           - "ES512"
-	  - "PS256"
-	  - "PS384"
-	  - "PS512"
+          - "PS256"
+          - "PS384"
+          - "PS512"
       kid:
         type: "string"
         description: |
-          The kid (key ID) Header Parameter is a hint indicating which key
-          was used to secure the JWS.  This parameter allows originators to
-          explicitly signal a change of key to recipients.  The structure of
-          the kid value is unspecified.  Its value MUST be a case-sensitive
-          string.  Use of this Header Parameter is OPTIONAL.
-          see https://tools.ietf.org/html/rfc7515#section-4.1.4
+          The kid (key identifier) Header Parameter as defined in RFC 7515.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#22-key-id.
+          This Header Parameter is OPTIONAL.
+      typ:
+        type: "string"
+        description: |
+          The `typ` (type) Header Parameter as defined in RFC 7519.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#23-type.
+          This Header Parameter is OPTIONAL.
+        enum:
+          - "JWT"
+          - "JOSE"
     required:
       - "alg"
   payload:
@@ -44,38 +44,24 @@ properties:
     properties:
       sub:
         type: "string"
-	description: |
-	  The "sub" (subject) claim identifies the principal that is the
-	  subject of the JWT.  The claims in a JWT are normally statements
-	  The processing of this claim is generally application specific.  The
-	  "sub" value is a case-sensitive string containing a StringOrURI
-	  value.
-	  see https://tools.ietf.org/html/rfc7519#section-4.1.2
+        description: |
+          The `sub` (subject) claim as defined in RFC 7519.
+          For JWT-SVIDs, the "sub" claim contains the SPIFFE ID.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#31-subject
+          This claim is REQUIRED.
       aud:
         type: "string"
         description: |
-          A JSON string value, with the additional requirement that while
-          arbitrary string values MAY be used, any value containing a ":"
-          character MUST be a URI [RFC3986].  StringOrURI values are
-          compared as case-sensitive strings with no transformations or
-          canonicalizations applied.
-          see https://tools.ietf.org/html/rfc7519#section-4.1.3
+          The "aud" (audience) claim as defined in RFC 7519.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#32-audience
+          This claim is REQUIRED.
       exp:
         type: "integer"
         description: |
-          The "exp" (expiration time) claim identifies the expiration time on
-          or after which the JWT MUST NOT be accepted for processing.  The
-          processing of the "exp" claim requires that the current date/time
-          MUST be before the expiration date/time listed in the "exp" claim.
-          Implementers MAY provide for some small leeway, usually no more than
-          a few minutes, to account for clock skew.  Its value MUST be a number
-          containing a NumericDate value.  Use of this claim is OPTIONAL.
-          see https://tools.ietf.org/html/rfc7519#section-4.1.4
+          The "exp" (expiration time) claim as defined in RFC 7519.
+          See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#33-expiration-time
+          This claim is REQUIRED.
     required:
       - "sub"
       - "aud"
       - "exp"
-    additionalProperties: false
-    patternProperties:
-      \w+:(\/?\/?)[^\s]+:
-        type: "string"


### PR DESCRIPTION
This change updates the schema to reflect the spec. Specifically:

- Defines the `typ` header value
- Removes the restrictive property pattern
- Allows additional properties

The change also cleans up some of the property descriptions, pointing
now to the relevant RFCs and JWT-SVID spec text.

Fixes: #193