### PR TITLE
Update 2021H2 ssc election readme timeline

### DIFF
--- a/ssc/elections/2021H2/README.md
+++ b/ssc/elections/2021H2/README.md
@@ -2,14 +2,19 @@
 This subdirectory captures the nominees and results of the 2021 H2 SSC election. The timeline for this election is as follows:
 * Oct 6, 2021: Nominations open
 * Oct 20, 2021: Nominations close
-* Oct 27, 2021: Polls open
-* Nov 3, 2021: Polls close
-* Nov 8, 2021: Results announced
+* Oct 28, 2021: Polls open
+* Nov 4, 2021: Polls close
+* Nov 9, 2021: Results announced
 
 For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/194).
 
 ## Nominations
-To be announced.
+* [Andres Vega](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/ANDRES_VEGA.md)
+* [Andrew Moore](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/ANDREW_MOORE.md)
+* [Brian Martin](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/BRIAN_MARTIN.md)
+* [Ed Warnicke](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/ED_WARNICKE.md)
+* [Geri Jennings](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/GERI_JENNINGS.md)
+* [Jeyappragash JJ](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/JEYAPPRAGASH_JJ.md)
 
 ## Results
 To be announced.

--- a/ssc/elections/2021H2/README.md
+++ b/ssc/elections/2021H2/README.md
@@ -1,10 +1,10 @@
 # 2021 H2 SSC Election
 This subdirectory captures the nominees and results of the 2021 H2 SSC election. The timeline for this election is as follows:
 * Oct 6, 2021: Nominations open
-* Oct 13, 2021: Nominations close
-* Oct 20, 2021: Polls open
-* Oct 27, 2021: Polls close
-* Nov 1, 2021: Results announced
+* Oct 20, 2021: Nominations close
+* Oct 27, 2021: Polls open
+* Nov 3, 2021: Polls close
+* Nov 8, 2021: Results announced
 
 For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/194).
 


### PR DESCRIPTION
This commit updates the timeline documented in the 2021 H2 election
README to reflect updated timing as commented in #194.

Signed-off-by: Evan Gilman <egilman@vmware.com>