### PR TITLE
Record 2021 H2 SSC Election Results

### DIFF
--- a/ssc/README.md
+++ b/ssc/README.md
@@ -6,14 +6,6 @@ Please read the [SSC Charter](CHARTER.md) for more information about the SSC's r
 ## SSC Members
 The current members of the SSC, ordered by term,  are as follows:
 
-**Joe Beda** (@jbeda)  
-[GitHub](https://github.com/jbeda) | [LinkedIn](https://www.linkedin.com/in/jbeda)  
-Term end: November 3rd, 2021  
-
-**Emiliano Berenbaum** (@y2bishop2y)  
-[GitHub](https://github.com/y2bishop2y) | [LinkedIn](https://www.linkedin.com/in/eberenb)  
-Term end: November 3rd, 2021  
-
 **Evan Gilman** (@evan2645)  
 [GitHub](https://github.com/evan2645) | [LinkedIn](https://www.linkedin.com/in/evan2645)  
 Term end: May 4th, 2022  
@@ -25,3 +17,12 @@ Term end: May 3rd, 2023
 **Frederick Kautz** (@fkautz)  
 [GitHub](https://github.com/fkautz) | [LinkedIn](https://www.linkedin.com/in/fkautz/)  
 Term end: May 3rd, 2023  
+
+**Andres Vega** (@anvega)  
+[GitHub](https://github.com/anvega) | [LinkedIn](https://www.linkedin.com/in/avegaarias/)  
+Term end: November 1st, 2023  
+
+**Andrew Moore** (@amoore877)  
+[GitHub](https://github.com/amoore877) | [LinkedIn](https://www.linkedin.com/in/andrew-moore-681b1114a/)  
+Term end: November 1st, 2023  
+

--- a/ssc/elections/2021H2/README.md
+++ b/ssc/elections/2021H2/README.md
@@ -4,7 +4,7 @@ This subdirectory captures the nominees and results of the 2021 H2 SSC election.
 * Oct 20, 2021: Nominations close
 * Oct 28, 2021: Polls open
 * Nov 4, 2021: Polls close
-* Nov 9, 2021: Results announced
+* Nov 16, 2021: Results announced
 
 For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/194).
 
@@ -17,4 +17,5 @@ For more information on how to participate, please see the relevant GitHub [trac
 * [Jeyappragash JJ](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/JEYAPPRAGASH_JJ.md)
 
 ## Results
-To be announced.
+* [Andres Vega](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/ANDRES_VEGA.md)
+* [Andrew Moore](https://github.com/spiffe/spiffe/blob/main/ssc/elections/2021H2/ANDREW_MOORE.md)


### PR DESCRIPTION
Welcome to @anvega and @amoore877 as the newest SSC members, who will be replacing Joe Beda and Emiliano Berenbaum. Thank you to Joe and Emiliano for all your help over the years!

This concludes the 2021 H2 election cycle tracked in #194 

Signed-off-by: Evan Gilman <egilman@vmware.com>