### PR TITLE
Skip dependabot[bot] in vote discovery script

### DIFF
--- a/ssc/elections/script/find_eligible_voters.sh
+++ b/ssc/elections/script/find_eligible_voters.sh
@@ -79,7 +79,7 @@ INELIGIBLE_VOTERS=""
 echo
 echo
 for VOTER in $ELIGIBLE_VOTERS; do
-    if [ "$VOTER" == "dependabot[bot]" ]; then
+	if [ "$VOTER" == "dependabot[bot]" ]; then
 		continue
 	fi
 

--- a/ssc/elections/script/find_eligible_voters.sh
+++ b/ssc/elections/script/find_eligible_voters.sh
@@ -79,6 +79,10 @@ INELIGIBLE_VOTERS=""
 echo
 echo
 for VOTER in $ELIGIBLE_VOTERS; do
+    if [ "$VOTER" == "dependabot[bot]" ]; then
+		continue
+	fi
+
 	USER_RESP=`$CURL/users/$VOTER`
 	NAME=`echo "$USER_RESP" | jq '.name' | sed 's/^"//' | sed 's/"$//'`
 	EMAIL=`echo "$USER_RESP" | jq '.email' | sed 's/^"//' | sed 's/"$//'`


### PR DESCRIPTION
Bots don't have rights.

Also prevent failure in script lookup for a bot's meta information.