### PR TITLE
Adds initial volunteers page.

### DIFF
--- a/community/volunteers.md
+++ b/community/volunteers.md
@@ -4,7 +4,7 @@ Some notes:
 * *If you are coordinating an event and looking for a speaker or other support on SPIFFE, feel free to reach out to any of those listed below. Inclusion on this list is for the convienence of event organizers, and does not imply a commitment by any of the speakers to participate in any particular event.*
 *  *While we strive to ensure all speakers listed below respect and closely follow our [Code of Conduct](../CODE-OF-CONDUCT.md), and will remove those that do not, inclusion in this list does not represent an endorsement of that individual from the SPIFFE community. Please conduct your own due diligence before inviting anyone from this list to an event.*
 
-| Who | Contact | Location | Preferred speaking topics | Preferred duties |
+| Who | Contact | Location | Preferred speaking topics | Preferred duties | Volunteer Notes
 | --- | ------- | -------- | ------------------------- | ----------------- |
 | Andrew Jessup | [Slack Profile](https://spiffe.slack.com/team/U3D29M4JC) | Ann Arbor, USA | Introduction, project history, use cases | Webinars, Speaking or supporting local events |
 | Daniel Feldman | [Slack Profile](https://spiffe.slack.com/team/UA5G0MH62) | Minneapolis, USA | Please ask | Please ask |

--- a/community/volunteers.md
+++ b/community/volunteers.md
@@ -1,0 +1,16 @@
+This page lists members of the SPIFFE community who have signalled a willigness to represent the SPIFFE project at various public fora, which may include public events (such as KubeCon maintainers talks or conference booths), virtual events (such as CNCF Webinars), or other events.
+
+Some notes:
+* *If you are coordinating an event and looking for a speaker or other support on SPIFFE, feel free to reach out to any of those listed below. Inclusion on this list is for the convienence of event organizers, and does not imply a commitment by any of the speakers to participate in any particular event.*
+*  *While we strive to ensure all speakers listed below respect and closely follow our [Code of Conduct](../CODE-OF-CONDUCT.md), and will remove those that do not, inclusion in this list does not represent an endorsement of that individual from the SPIFFE community. Please conduct your own due diligence before inviting anyone from this list to an event.*
+
+| Who | Contact | Location | Preferred speaking topics | Preferred duties |
+| --- | ------- | -------- | ------------------------- | ----------------- |
+| Andrew Jessup | [Slack Profile](https://spiffe.slack.com/team/U3D29M4JC) | Ann Arbor, USA | Introduction, project history, use cases | Webinars, Speaking or supporting local events |
+| Daniel Feldman | [Slack Profile](https://spiffe.slack.com/team/UA5G0MH62) | Minneapolis, USA | Please ask | Please ask |
+| Andrew Moore | [Slack Profile](https://spiffe.slack.com/team/UG75JQCR1) | Seattle, USA | Please ask | Please ask |
+| Sunil Ravipati | - | Santa Clara, USA | Please ask | Please ask |
+
+In addition to the speakers listed below, you may wish to reach out to [the #community channel](https://spiffe.slack.com/messages/C01DNVCF9CP) on the SPIFFE Slack Workspace.
+
+To add yourself to, or remove yourself from, this list, submit a pull request to modify this page. If you are nominating someone else, please be sure to demonstrate you have their permission.

--- a/community/volunteers.md
+++ b/community/volunteers.md
@@ -8,7 +8,7 @@ Some notes:
 | --- | ------- | -------- | ------------------------- | ----------------- |
 | Andrew Jessup | [Slack Profile](https://spiffe.slack.com/team/U3D29M4JC) | Ann Arbor, USA | Introduction, project history, use cases | Webinars, Speaking or supporting local events |
 | Daniel Feldman | [Slack Profile](https://spiffe.slack.com/team/UA5G0MH62) | Minneapolis, USA | Please ask | Please ask |
-| Andrew Moore | [Slack Profile](https://spiffe.slack.com/team/UG75JQCR1) | Seattle, USA | Please ask | Please ask |
+| Andrew Moore | [Slack Profile](https://spiffe.slack.com/team/UG75JQCR1) | Seattle, USA | Introduction, use cases, operational experience | Webinars, Speaking |
 | Sunil Ravipati | - | Santa Clara, USA | Please ask | Please ask |
 
 In addition to the speakers listed below, you may wish to reach out to [the #community channel](https://spiffe.slack.com/messages/C01DNVCF9CP) on the SPIFFE Slack Workspace.


### PR DESCRIPTION
In a recent SSC call, it was proposed we create a directory of volunteers for the SPIFFE project who may be willing to participate in certain duties on behalf of the project, such as booth duty or public speaking.

This PR is to create the initial directory, with the expectation that we would invite other community members who were willing to add their names via subsequent pull requests.

This initial PR also adds @dfeldman @amoore877 @ajessup and Sunil Ravipati who verbally acknowledged on the SSC call that they were willing to be included.