### PR TITLE
Add 2023H1 election dir and README

### DIFF
--- a/ssc/elections/2023H1/README.md
+++ b/ssc/elections/2023H1/README.md
@@ -1,0 +1,15 @@
+# 2023 H1 SSC Election
+This subdirectory captures the nominees and results of the 2023 H1 SSC election. The timeline for this election is as follows:
+* April 5th, 2023: Nominations open
+* April 19th, 2023: Nominations close
+* April 26th, 2023: Polls open
+* May 3rd, 2023: Polls close. Results announced within days.
+* May 10th, 2023: Term Start
+
+For more information on how to participate, please see the relevant GitHub [tracking issue](https://github.com/spiffe/spiffe/issues/244).
+
+## Nominees
+TBA
+
+## Results
+TBA


### PR DESCRIPTION
This PR creates the 2023 H1 election directory, and sets the README there. I basically guessed at the updated timeline because I know that the nomination period was extended but the tracking issue wasn't updated so I don't know if the dates here are accurate or not.