### PR TITLE
Make SSC eligibility more clear

### DIFF
--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ This is the official tracking issue for the YYYY [H1,H2] SSC election. The timel
 
 ## How to Participate
 All SPIFFE community members and contributors demonstrating active engagement in the project(s) are invited to both nominate and vote on new SSC members.
-An initial batch of eligible participants discovered via automation are listed below.
+An initial batch of eligible participants discovered via automation is listed below.
 
 For more information about the definition of active engagement, and how this list was compiled, please see the Election and Term Mechanics section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#election-and-term-mechanics).
 

--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -13,7 +13,7 @@ An initial batch of eligible participants discovered via automation is listed be
 For more information about the definition of active engagement, and how this list was compiled, please see the Election and Term Mechanics section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#election-and-term-mechanics).
 
 If you feel that you are an active SPIFFE community member or contributor but are not included in the list below, please contact the SSC at ssc-elections@spiffe.io and we will be happy to include you.
-Even if you do not interact with GitHub normally, a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
+Even if you do not interact with GitHub normally, to be an election candidate a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
 
 ### Nominating an SSC Member
 Eligible participants may nominate up to two candidates per available SSC seat during the nomination period. They may nominate themselves or someone else.

--- a/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
+++ b/ssc/elections/ELECTION_ISSUE_TEMPLATE.md
@@ -7,11 +7,13 @@ This is the official tracking issue for the YYYY [H1,H2] SSC election. The timel
 * MONTH DAY, YEAR: Results announced
 
 ## How to Participate
-All SPIFFE community members and contributors demonstrating active engagement in the project(s) are invited to both nominate and vote on new SSC members. The eligible participants are listed below. For more information about the definition of active engagement, and how this list was compiled, please see the Election and Term Mechanics section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#election-and-term-mechanics).
+All SPIFFE community members and contributors demonstrating active engagement in the project(s) are invited to both nominate and vote on new SSC members.
+An initial batch of eligible participants discovered via automation are listed below.
 
-All eligible participants MUST have an email address publicly associated with their GitHub account. You may be omitted from the participant list if we're unable to determine your email address.
+For more information about the definition of active engagement, and how this list was compiled, please see the Election and Term Mechanics section of the [SSC Charter](https://github.com/spiffe/spiffe/blob/master/ssc/CHARTER.md#election-and-term-mechanics).
 
 If you feel that you are an active SPIFFE community member or contributor but are not included in the list below, please contact the SSC at ssc-elections@spiffe.io and we will be happy to include you.
+Even if you do not interact with GitHub normally, a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
 
 ### Nominating an SSC Member
 Eligible participants may nominate up to two candidates per available SSC seat during the nomination period. They may nominate themselves or someone else.

--- a/ssc/elections/README.md
+++ b/ssc/elections/README.md
@@ -12,13 +12,16 @@ All nominees are proposed via GitHub Pull Request, and each nominee gets a dedic
 
 The rest of this section captures the exact steps necessary to begin and complete an SSC election. These steps are to be performed by an SSC member, or appointed party.
 
+Eligible participants are initially found via a GitHub search, since all other discovery processes would be manual. This is not intended as an exclusion of community members who are not active in GitHub but otherwise do participant in SPIFFE workstreams.
+However, a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
+
 ### Term Start-84 Days: Preparation
-1. Identify eligible participants
-	1. Eligible participants MUST have a public email address on their GitHub profile
+1. Identify initial batch of eligible participants using the `script` subfolder.
+	1. Automation of finding eligible participants requires a public email address on participant GitHub profiles
 1. Open GitHub issue to track election
 	1. The title should be `YYYY [H1,H2] SSC Election`
 	1. Use the text in `ELECTION_ISSUE_TEMPLATE.md` as the issue body, filling in the details as needed
-1. Announce the start of a new election cycle
+1. Announce the start of a new election cycle.
 	1. Slack #announcements channel
 	1. SIG mailing lists
 

--- a/ssc/elections/README.md
+++ b/ssc/elections/README.md
@@ -13,7 +13,7 @@ All nominees are proposed via GitHub Pull Request, and each nominee gets a dedic
 The rest of this section captures the exact steps necessary to begin and complete an SSC election. These steps are to be performed by an SSC member, or appointed party.
 
 Eligible participants are initially found via a GitHub search, since all other discovery processes would be manual. This is not intended as an exclusion of community members who are not active in GitHub but otherwise do participant in SPIFFE workstreams.
-However, a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
+However, for candidates a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
 
 ### Term Start-84 Days: Preparation
 1. Identify initial batch of eligible participants using the `script` subfolder.

--- a/ssc/elections/README.md
+++ b/ssc/elections/README.md
@@ -12,7 +12,7 @@ All nominees are proposed via GitHub Pull Request, and each nominee gets a dedic
 
 The rest of this section captures the exact steps necessary to begin and complete an SSC election. These steps are to be performed by an SSC member, or appointed party.
 
-Eligible participants are initially found via a GitHub search, since all other discovery processes would be manual. This is not intended as an exclusion of community members who are not active in GitHub but otherwise do participant in SPIFFE workstreams.
+Eligible participants are initially found via a GitHub search, since all other discovery processes would be manual. This is not intended as an exclusion of community members who are not active in GitHub but otherwise do participate in SPIFFE workstreams.
 However, for candidates a GitHub account is required as this is how SSC members gain administrative rights on the SPIFFE projects.
 
 ### Term Start-84 Days: Preparation


### PR DESCRIPTION
From SSC sync, we found there may be confusion on who is eligible. We certainly don't require someone to have made GitHub contributions or been in GitHub issues/discussions.