### PR TITLE
make an initial README for how to contribute a new SPIFFE project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 
 /CODE-OF-CONDUCT.md @spiffe/ssc
 /GOVERNANCE.md      @spiffe/ssc
+/MATURITY.md        @spiffe/ssc
 /NEW_PROJECTS.md    @spiffe/ssc
 /README.md          @spiffe/ssc
 /community/         @spiffe/ssc

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 
 /CODE-OF-CONDUCT.md @spiffe/ssc
 /GOVERNANCE.md      @spiffe/ssc
+/NEW_PROJECTS.md    @spiffe/ssc
 /README.md          @spiffe/ssc
 /community/         @spiffe/ssc
 /ssc/               @spiffe/ssc

--- a/MATURITY.md
+++ b/MATURITY.md
@@ -3,6 +3,8 @@ SPIFFE comprises a handful of software projects, all of which share a common gov
 
 This document provides detailed information about the maturity phases of the various projects that are part of the overarching [SPIFFE project](https://github.com/spiffe).
 
+To be considered as a new SPIFFE project, see instructions at [NEW_PROJECTS](/NEW_PROJECTS.md).
+
 The SPIFFE project maintains three phases of maturity which indicate the level of reliability and scale at which a particular project or sub-project is known to support:
 - **Development**: The software is still under active development, and many efforts are exploratory. APIs and interfaces may change rapidly and without warning. Use this software for development and proof of concept purposes, but stability and longevity is not guaranteed.
 - **Pre-Production**: The software is relatively stable and being used to solve real problems. APIs and interfaces may change, but effort will be made to consider compatibility. Use this software for integration investigation and technology evaluation. Some early adopters may choose to run this software in production, however it is not recommended. Deprecation of this software is unlikely.

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -1,0 +1,66 @@
+# Creating a new SPIFFE Project
+
+We are grateful for your desire to expand the SPIFFE ecosystem with your contribution!
+
+This is an evolving set of guidelines and instructions for how to bring your existing project, or idea for a completely fresh project, under the SPIFFE organization.
+
+If your project is already under the SPIFFE banner, you may be looking for [MATURITY](/MATURITY.md) instead.
+
+## Notice
+
+Maintainer groups are given significant freedom in managing their projects to that we may best foster growth and innovation. There are some elements of SPIFFE subproject ownership to be aware of:
+The [SPIFFE Steering Committee](/ssc/README.md) (SSC) governs the SPIFFE organization as a whole, and has the final authority on acceptance, rejection, or eviction of projects. Additionally, as stewards of community health, the SSC is responsible for intervening in any [Code of Conduct](/CODE-OF-CONDUCT.md) violations or derelictions of maintainer responsibility.
+Note that when contributing a project to SPIFFE, its purpose becomes to serve the SPIFFE community rather than any personal gain. Additionally, we expect a sufficient number of maintainers for the project, not all of whom may bring the same direction you may originally have had in mind.
+Carefully consider this change in control and purpose.
+
+*Every SPIFFE project* at minimum must follow the [SPIFFE Code of Conduct](/CODE-OF-CONDUCT.md).
+
+## Project Proposal
+
+### Contact
+
+The SSC can be contacted with proposal details at ssc@spiffe.io or on [our SPIFFE slack channel](https://spiffe.slack.com/archives/C01GQ267JJU).
+
+### Proposal Outline
+
+The following details are expected for proposals to help us best understand how the project will serve the community.
+
+Additionally, the information here make great initial `README.md`, `CONTRIBUTING.md`, and `GOVERNANCE.md` files for the repo!
+
+#### Initial Maintainer List
+
+The list of initial maintainers of the project, including GitHub handle.
+
+#### Project Purpose and Direction
+
+What need is the project solving for the community? What problem exists or what enhancement will this create?
+
+What is the *direction* of the project? This is similar but distinct from the *purpose* of the project.
+While the purpose highlights the "Why" and "What" of the project, the direction should be about the "How".
+This could include:
+- What does "done" mean for the project? What is the idealized vision for the shape of the project? What are the milestones to complete for each level of [maturity](/MATURITY.md)?
+- What are practices or styles that will be encouraged or discouraged?
+- What notable features or options are in-scope or out-of-scope for the project? This especially will help differentiate your project from any similar ones that might already exist.
+It's ok if there's not fully fleshed-out answers to each of these, and projects evolve over time. However the more information that can be provided the more easily SSC may understand the proposal, and the more confidence there will be in alignment amongst the maintainers.
+
+#### Governance
+
+The operations of the project.
+
+How will maintainers be added or removed? What is the goal number of maintainers?
+How often will the maintainers meet?
+How will maintainers interact with contributors and review their Pull Requests and Issues? Slack? Dedicated online meetings? What is the goal turn around time?
+
+#### Similar Projects
+
+Do similar projects already exist actively within the SPIFFE community? If so, what makes this project sufficiently unique to justify any overlap?
+
+Do similar projects exist outside of SPIFFE that can better help us understand the project's value?
+
+Has this project existed in the past but was abandoned or closed out? What is different in today's world?
+
+## Project Review
+
+The SSC will work with you to schedule a review of the proposal. Ideally all initial maintainers would be present in that review. Anyone not present should at least sign off on the proposal so that we know there is a unified commitment.
+
+The SSC will bring up any concerns around the proposal, but overall we aim to accept proposals that serve even a subsection of the community as long as there is confidence that the project will be healthy.

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -76,11 +76,10 @@ It's ok if there's not fully fleshed-out answers to each of these, and projects 
 
 The operations of the project.
 
-How will maintainers be added or removed? What is the goal number of maintainers?
-
-How often will the maintainers meet?
-
-How will maintainers interact with contributors and review their Pull Requests and Issues? Slack? Dedicated online meetings? What is the goal turn around time?
+- How will maintainers be added or removed? What is the goal number of maintainers?
+- How often will the maintainers meet?
+- How will maintainers interact with contributors and review their Pull Requests and Issues? Slack? Dedicated online meetings? What is the goal turn around time?
+- What conflict resolution mechnisms will the maintainers follow?
 
 #### Similar Projects
 

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -8,7 +8,7 @@ You may be interested in contributing a project to SPIFFE in order to:
 - Build on top of one or multiple existing solutions as a unique offering
 or other possible motivations.
 
-# Creating a new SPIFFE Project
+# Creating or donating a new SPIFFE Project
 
 We are grateful for your desire to expand the SPIFFE ecosystem with your contribution!
 

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -1,3 +1,13 @@
+# Introduction
+
+The Secure Production Identity Framework For Everyone (SPIFFE) Project defines a framework and set of standards for identifying and securing communications between application services. You can read more about it at the [README](/README.md).
+
+You may be interested in contributing a project to SPIFFE in order to:
+- Fill some technological or use case gap
+- Enhance UX for operators of a SPIFFE solution such as [SPIRE](https://github.com/spiffe/spire).
+- Build on top of one or multiple existing solutions as a unique offering
+or other possible motivations.
+
 # Creating a new SPIFFE Project
 
 We are grateful for your desire to expand the SPIFFE ecosystem with your contribution!

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -49,10 +49,26 @@ What need is the project solving for the community? What problem exists or what 
 What is the *direction* of the project? This is similar but distinct from the *purpose* of the project.
 
 While the purpose highlights the "Why" and "What" of the project, the direction should be about the "How".
-This could include:
+This could include-
+Vision:
+- What specific pain point does the project address?
 - What does "done" mean for the project? What is the idealized vision for the shape of the project? What are the milestones to complete for each level of [maturity](/MATURITY.md)?
-- What are practices or styles that will be encouraged or discouraged?
 - What notable features or options are in-scope or out-of-scope for the project? This especially will help differentiate your project from any similar ones that might already exist.
+- What are the current workarounds or alternative solutions, and why are they inadequate?
+- How does your project align with SPIFFE's overall mission and goals?
+- Who are the primary end-users or beneficiaries of this project?
+
+Direction:
+- What is the project’s roadmap for the next 6-12 months?
+- What are practices or styles that will be encouraged or discouraged?
+- How will the project scale? What are the scalability goals?
+- Are there any legal or ethical considerations?
+- What are potential challenges, and how do you plan to overcome them?
+- What kind of community involvement do you foresee (e.g., are there opportunities for novice contributors, or is the project more suitable for experts in the field?)
+- What technologies will the project leverage, and are they aligned with the larger ecosystem?
+- How will the project maintain data integrity, security, and privacy?
+- Are there any possible collaborations with existing SPIFFE projects?
+- How will your project deal with failure scenarios or fallbacks?
 
 It's ok if there's not fully fleshed-out answers to each of these, and projects evolve over time. However the more information that can be provided the more easily SSC may understand the proposal, and the more confidence there will be in alignment amongst the maintainers.
 

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -36,11 +36,13 @@ The list of initial maintainers of the project, including GitHub handle.
 What need is the project solving for the community? What problem exists or what enhancement will this create?
 
 What is the *direction* of the project? This is similar but distinct from the *purpose* of the project.
+
 While the purpose highlights the "Why" and "What" of the project, the direction should be about the "How".
 This could include:
 - What does "done" mean for the project? What is the idealized vision for the shape of the project? What are the milestones to complete for each level of [maturity](/MATURITY.md)?
 - What are practices or styles that will be encouraged or discouraged?
 - What notable features or options are in-scope or out-of-scope for the project? This especially will help differentiate your project from any similar ones that might already exist.
+
 It's ok if there's not fully fleshed-out answers to each of these, and projects evolve over time. However the more information that can be provided the more easily SSC may understand the proposal, and the more confidence there will be in alignment amongst the maintainers.
 
 #### Governance
@@ -48,7 +50,9 @@ It's ok if there's not fully fleshed-out answers to each of these, and projects 
 The operations of the project.
 
 How will maintainers be added or removed? What is the goal number of maintainers?
+
 How often will the maintainers meet?
+
 How will maintainers interact with contributors and review their Pull Requests and Issues? Slack? Dedicated online meetings? What is the goal turn around time?
 
 #### Similar Projects

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -94,3 +94,5 @@ Has this project existed in the past but was abandoned or closed out? What is di
 The SSC will work with you to schedule a review of the proposal. Ideally all initial maintainers would be present in that review. Anyone not present should at least sign off on the proposal so that we know there is a unified commitment.
 
 The SSC will bring up any concerns around the proposal, but overall we aim to accept proposals that serve even a subsection of the community as long as there is confidence that the project will be healthy.
+
+The SSC meets regularly, and will do its best to come to resolution within a couple sync cycles. Acceptance of a new project into the community is a significant decision, and your patience is appreciated.

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -19,8 +19,9 @@ If your project is already under the SPIFFE banner, you may be looking for [MATU
 ## Notice
 
 Maintainer groups are given significant freedom in managing their projects to that we may best foster growth and innovation. There are some elements of SPIFFE subproject ownership to be aware of:
-The [SPIFFE Steering Committee](/ssc/README.md) (SSC) governs the SPIFFE organization as a whole, and has the final authority on acceptance, rejection, or eviction of projects. Additionally, as stewards of community health, the SSC is responsible for intervening in any [Code of Conduct](/CODE-OF-CONDUCT.md) violations or derelictions of maintainer responsibility.
-Note that when contributing a project to SPIFFE, its purpose becomes to serve the SPIFFE community rather than any personal gain. Additionally, we expect a sufficient number of maintainers for a project as it grows, not all of whom may bring the same direction you may originally have had in mind.
+- The [SPIFFE Steering Committee](/ssc/README.md) (SSC) governs the SPIFFE organization as a whole, and has the final authority on acceptance, rejection, or eviction of projects. Additionally, as stewards of community health, the SSC is responsible for intervening in any [Code of Conduct](/CODE-OF-CONDUCT.md) violations or derelictions of maintainer responsibility.
+- Note that when contributing a project to SPIFFE, its purpose becomes to serve the SPIFFE community rather than any personal gain. Additionally, we expect a sufficient number of maintainers for a project as it grows, not all of whom may bring the same direction you may originally have had in mind.
+
 Carefully consider this change in control and purpose.
 
 *Every SPIFFE project* at minimum must follow the [SPIFFE Code of Conduct](/CODE-OF-CONDUCT.md).

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -10,7 +10,7 @@ If your project is already under the SPIFFE banner, you may be looking for [MATU
 
 Maintainer groups are given significant freedom in managing their projects to that we may best foster growth and innovation. There are some elements of SPIFFE subproject ownership to be aware of:
 The [SPIFFE Steering Committee](/ssc/README.md) (SSC) governs the SPIFFE organization as a whole, and has the final authority on acceptance, rejection, or eviction of projects. Additionally, as stewards of community health, the SSC is responsible for intervening in any [Code of Conduct](/CODE-OF-CONDUCT.md) violations or derelictions of maintainer responsibility.
-Note that when contributing a project to SPIFFE, its purpose becomes to serve the SPIFFE community rather than any personal gain. Additionally, we expect a sufficient number of maintainers for the project, not all of whom may bring the same direction you may originally have had in mind.
+Note that when contributing a project to SPIFFE, its purpose becomes to serve the SPIFFE community rather than any personal gain. Additionally, we expect a sufficient number of maintainers for a project as it grows, not all of whom may bring the same direction you may originally have had in mind.
 Carefully consider this change in control and purpose.
 
 *Every SPIFFE project* at minimum must follow the [SPIFFE Code of Conduct](/CODE-OF-CONDUCT.md).

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -79,7 +79,7 @@ The operations of the project.
 - How will maintainers be added or removed? What is the goal number of maintainers?
 - How often will the maintainers meet?
 - How will maintainers interact with contributors and review their Pull Requests and Issues? Slack? Dedicated online meetings? What is the goal turn around time?
-- What conflict resolution mechnisms will the maintainers follow?
+- What conflict resolution mechnisms will the maintainers follow? (e.g., allocated debate time? Majority vote? Unanimous vote for certain topics? What is the SLO for resolution?)
 
 #### Similar Projects
 

--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -30,7 +30,7 @@ Carefully consider this change in control and purpose.
 
 ### Contact
 
-The SSC can be contacted with proposal details at ssc@spiffe.io or on [our SPIFFE slack channel](https://spiffe.slack.com/archives/C01GQ267JJU).
+The SSC can be contacted with proposal details at ssc@spiffe.io or in [the #ssc channel](https://spiffe.slack.com/archives/C01GQ267JJU) of [SPIFFE slack](https://slack.spiffe.io).
 
 ### Proposal Outline
 


### PR DESCRIPTION
Based off the SSC sync today, we learned that while we have guidance on project maturity we do not have guidance on how to bring a project or project idea into the SPIFFE organization.

Create an initial guide on this with what I hope are the least controversial elements possible, and that we can then build upon over time. Put that guide under SSC control in `CODEOWNERS`

Also add `MATURITY.md` under SSC control in `CODEOWNERS` while here.