### PR TITLE
fix Mohamed Omar's election entry for GitHub

### DIFF
--- a/ssc/elections/2023H2/MOHAMED_OMAR.md
+++ b/ssc/elections/2023H2/MOHAMED_OMAR.md
@@ -4,7 +4,7 @@ He has participated in the SPIFFE community for over 2 years and would be an exc
 
 ## Reference
 **Email:** momar@confluent.io
-**GitHub:** https://github.com/moemar
+**GitHub:** https://github.com/moe-omar
 **LinkedIn Profile:** https://www.linkedin.com/in/moeomar/
 **Current Affiliation:** Confluent
 **Recent presentation:** https://www.youtube.com/watch?v=cKEQy0Vi8wc


### PR DESCRIPTION
Typo was made during election issue #258 , putting wrong GH entry for candidate (who is now elected)