### PR TITLE
Begin an onboarding, offboarding doc for SSC

### DIFF
--- a/ssc/ONBOARDING.md
+++ b/ssc/ONBOARDING.md
@@ -9,6 +9,7 @@ Remember, with great power comes great responsibility.
 [ ] Password / account handoff, or entirely new account creation, for Admin powers on the spiffe.io domain in Gsuite. For auditability, each SSC member has their own privileged acount.
 [ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
 [ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
+[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] is updated.
 [ ] Choose a secure personal email to be added to ssc@spiffe.io in Gsuite.
 [ ] Ensure you have a CNCF service desk account at http://servicedesk.cncf.io/. See (CNCF help)[https://github.com/cncf/servicedesk#i-dont-have-a-servicedesk-account] for steps.
 [ ] Ensure you are added as a SPIFFE Slack Workspace Admin at https://spiffe.slack.com/admin.
@@ -20,5 +21,6 @@ Offboarding is largely the opposite of Onboarding:
 [ ] Handoff or ensure deletion of your privileged Gsuite account in the spiffe.io domain.
 [ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
 [ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
+[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] is removed.
 [ ] Ensure your personal email is removed from ssc@spiffe.io in Gsuite.
 [ ] Ensure you are downgraded to Workspace Member in SPIFFE Slack at https://spiffe.slack.com/admin.

--- a/ssc/ONBOARDING.md
+++ b/ssc/ONBOARDING.md
@@ -9,7 +9,7 @@ Remember, with great power comes great responsibility.
 [ ] Password / account handoff, or entirely new account creation, for Admin powers on the spiffe.io domain in Gsuite. For auditability, each SSC member has their own privileged acount.
 [ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
 [ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
-[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] is updated.
+[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] role is added.
 [ ] Choose a secure personal email to be added to ssc@spiffe.io in Gsuite.
 [ ] Ensure you have a CNCF service desk account at http://servicedesk.cncf.io/. See (CNCF help)[https://github.com/cncf/servicedesk#i-dont-have-a-servicedesk-account] for steps.
 [ ] Ensure you are added as a SPIFFE Slack Workspace Admin at https://spiffe.slack.com/admin.
@@ -20,7 +20,7 @@ Offboarding is largely the opposite of Onboarding:
 
 [ ] Handoff or ensure deletion of your privileged Gsuite account in the spiffe.io domain.
 [ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
-[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
+[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] role is removed (changed to regular member).
 [ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] is removed.
 [ ] Ensure your personal email is removed from ssc@spiffe.io in Gsuite.
 [ ] Ensure you are downgraded to Workspace Member in SPIFFE Slack at https://spiffe.slack.com/admin.

--- a/ssc/ONBOARDING.md
+++ b/ssc/ONBOARDING.md
@@ -1,0 +1,24 @@
+# SPIFFE Steering Committee Onboarding
+
+Congratulations!
+
+The following is an evolving checklist of administrative items to complete, either by you the new member or by an existing member so that you may execute your responsibilities with as few permission roadblocks as reasonable.
+
+Remember, with great power comes great responsibility.
+
+[ ] Password / account handoff, or entirely new account creation, for Admin powers on the spiffe.io domain in Gsuite. For auditability, each SSC member has their own privileged acount.
+[ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
+[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
+[ ] Choose a secure personal email to be added to ssc@spiffe.io in Gsuite.
+[ ] Ensure you have a CNCF service desk account at http://servicedesk.cncf.io/. See (CNCF help)[https://github.com/cncf/servicedesk#i-dont-have-a-servicedesk-account] for steps.
+[ ] Ensure you are added as a SPIFFE Slack Workspace Admin at https://spiffe.slack.com/admin.
+
+# SPIFFE Steering Committee Offboarding
+
+Offboarding is largely the opposite of Onboarding:
+
+[ ] Handoff or ensure deletion of your privileged Gsuite account in the spiffe.io domain.
+[ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
+[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
+[ ] Ensure your personal email is removed from ssc@spiffe.io in Gsuite.
+[ ] Ensure you are downgraded to Workspace Member in SPIFFE Slack at https://spiffe.slack.com/admin.


### PR DESCRIPTION
Previously onboarding/offboarding to SSC was a rough set of notes in a Gdoc.

Make the process more discoverable and maintainable by adding directly to the SPIFFE repo.

We can certainly update this process over time, but right now these steps are the known required ones and gives us an initial baseline to start from.