### PR TITLE
tiny projects group links; tidying markdown

### DIFF
--- a/NEW_PROJECTS.md
+++ b/NEW_PROJECTS.md
@@ -34,7 +34,7 @@ Some projects may be very small and yet still:
 
 These are core overriding changes for such projects:
 - The threshold for rationale of a separate project rather than inclusion in another is likely to be higher
-- There will be more tolerance for lighter core maintainer membership, which may be supplemented by a "tiny projects" maintainer group (today, the SSC) for trivial maintenance actions (ex. dependency updates, minor tidying):
+- There will be more tolerance for lighter core maintainer membership, which may be supplemented by a ["tiny projects" maintainer group](https://github.com/orgs/spiffe/teams/tiny-projects-maintainers/members) (today, the SSC) for trivial maintenance actions (ex. dependency updates, minor tidying):
 If this supplementing is needed:
 - the documentation, testing, quality bar for the project is likely to be higher. Supplemental maintainers may lack full context for the project and thus require reliable documentation discovery and testing tools.
 - the project will be more aggressively periodically reviewed for need- whether it is still in-use at all or should be archived

--- a/ssc/ONBOARDING.md
+++ b/ssc/ONBOARDING.md
@@ -7,22 +7,39 @@ The following is an evolving checklist of administrative items to complete, eith
 Remember, with great power comes great responsibility.
 
 [ ] Password / account handoff, or entirely new account creation, for Admin powers on the spiffe.io domain in Gsuite. For auditability, each SSC member has their own privileged acount.
-[ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
-[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] is updated.
-[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] role is added.
+
+[ ] Ensure [documented membership of SSC](README.md) is updated, as is the associated GitHub issue for the election.
+
+[ ] Ensure [membership of SSC in Github](https://github.com/orgs/spiffe/teams/ssc) is updated.
+
+[ ] Ensure [owner on the SPIFFE org](https://github.com/orgs/spiffe/people?query=role%3Aowner) role is added.
+
 [ ] Choose a secure personal email to be added to ssc@spiffe.io in Gsuite.
-[ ] Ensure you have a CNCF service desk account at http://servicedesk.cncf.io/. See (CNCF help)[https://github.com/cncf/servicedesk#i-dont-have-a-servicedesk-account] for steps.
+
+[ ] Ensure you have a CNCF service desk account at http://servicedesk.cncf.io/. See [CNCF help](https://github.com/cncf/servicedesk#i-dont-have-a-servicedesk-account) for steps.
+
 [ ] Ensure you are added as a SPIFFE Slack Workspace Owner at https://spiffe.slack.com/admin.
-[ ] An existing member of SSC needs to send you a (netlify)[app.netlify.com] invite for the SPIFFE org as an owner. Create a netlify account if needed.
+
+[ ] An existing member of SSC needs to send you a [netlify](app.netlify.com) invite for the SPIFFE org as an owner. Create a netlify account if needed.
+
+[ ] An existing member of SSC needs to add you to the [tiny projects maintainers group](https://github.com/orgs/spiffe/teams/tiny-projects-maintainers/members).
 
 # SPIFFE Steering Committee Offboarding
 
 Offboarding is largely the opposite of Onboarding:
 
 [ ] Handoff or ensure deletion of your privileged Gsuite account in the spiffe.io domain.
-[ ] Ensure (documented membership of SSC)[README.md] is updated, as is the associated GitHub issue for the election.
-[ ] Ensure (membership of SSC in Github)[https://github.com/orgs/spiffe/teams/ssc] role is removed (changed to regular member).
-[ ] Ensure (owner on the SPIFFE org)[https://github.com/orgs/spiffe/people?query=role%3Aowner] is removed.
+
+[ ] Ensure [documented membership of SSC](README.md) is updated, as is the associated GitHub issue for the election.
+
+[ ] Ensure [membership of SSC in Github](https://github.com/orgs/spiffe/teams/ssc) role is removed (changed to regular member).
+
+[ ] Ensure [owner on the SPIFFE org](https://github.com/orgs/spiffe/people?query=role%3Aowner) is removed.
+
 [ ] Ensure your personal email is removed from ssc@spiffe.io in Gsuite.
+
 [ ] Ensure you are downgraded to Workspace Member in SPIFFE Slack at https://spiffe.slack.com/admin.
-[ ] Ensure you are removed from the SPIFFE org in (netlify)[app.netlify.com].
+
+[ ] Ensure you are removed from the SPIFFE org in [netlify](app.netlify.com).
+
+[ ] If you no longer wish to maintain tiny projects, get removed from the [tiny projects maintainers group](https://github.com/orgs/spiffe/teams/tiny-projects-maintainers/members).


### PR DESCRIPTION
Link the new tiny projects maintainers group

Fix a bunch of markdown