### PR TITLE
Fix documentation typo

### DIFF
--- a/standards/SPIFFE_Workload_API.md
+++ b/standards/SPIFFE_Workload_API.md
@@ -287,7 +287,7 @@ message JWTSVID {
 // There are currently no request parameters.
 message JWTBundlesRequest { }
 
-// The JWTBundlesReponse conveys JWT bundles.
+// The JWTBundlesResponse conveys JWT bundles.
 message JWTBundlesResponse {
     // Required. JWK encoded JWT bundles, keyed by the SPIFFE ID of the trust
     // domain.
@@ -307,7 +307,7 @@ message ValidateJWTSVIDRequest {
     string svid = 2;
 }
 
-// The ValidateJWTSVIDReponse message conveys the JWT-SVID validation results.
+// The ValidateJWTSVIDResponse message conveys the JWT-SVID validation results.
 message ValidateJWTSVIDResponse {
     // Required. The SPIFFE ID of the validated JWT-SVID.
     string spiffe_id = 1;

--- a/standards/workloadapi.proto
+++ b/standards/workloadapi.proto
@@ -133,7 +133,7 @@ message JWTSVID {
 // There are currently no such parameters.
 message JWTBundlesRequest { }
 
-// The JWTBundlesReponse conveys JWT bundles.
+// The JWTBundlesResponse conveys JWT bundles.
 message JWTBundlesResponse {
     // Required. JWK encoded JWT bundles, keyed by the SPIFFE ID of the trust
     // domain.
@@ -153,7 +153,7 @@ message ValidateJWTSVIDRequest {
     string svid = 2;
 }
 
-// The ValidateJWTSVIDReponse message conveys the JWT-SVID validation results.
+// The ValidateJWTSVIDResponse message conveys the JWT-SVID validation results.
 message ValidateJWTSVIDResponse {
     // Required. The SPIFFE ID of the validated JWT-SVID.
     string spiffe_id = 1;


### PR DESCRIPTION
Noticed this while working on the Broker API spec. Not sure if this is worth a PR but didn't want to leave it unnoticed :)