### PR TITLE
Fix formatting of `ssc/README.md`

### DIFF
--- a/ssc/README.md
+++ b/ssc/README.md
@@ -6,13 +6,13 @@ Please read the [SSC Charter](CHARTER.md) for more information about the SSC's r
 ## SSC Members
 The current members of the SSC, ordered by term,  are as follows:
 
-**Arndt Schwenkschuster** @arndt-s
-[GitHub](https://github.com/arndt-s) | [LinkedIn](https://www.linkedin.com/in/arndtschw/)
-Term End: November 1st, 2027
+**Arndt Schwenkschuster** @arndt-s  
+[GitHub](https://github.com/arndt-s) | [LinkedIn](https://www.linkedin.com/in/arndtschw/)  
+Term End: November 1st, 2027  
 
-**Noah Stride** (@strideynet)
-[GitHub](https://github.com/strideynet) | [LinkedIn](https://www.linkedin.com/in/noah-stride/)
-Term End: November 1st, 2027
+**Noah Stride** (@strideynet)  
+[GitHub](https://github.com/strideynet) | [LinkedIn](https://www.linkedin.com/in/noah-stride/)  
+Term End: November 1st, 2027  
 
 **Volkan Ozcelik** (@v0lkan)  
 [GitHub](https://github.com/v0lkan) | [LinkedIn](https://www.linkedin.com/in/volkanozcelik)  


### PR DESCRIPTION
Apologies - looks like in my prior PR, I forgot to include the appropriate blank space at the end of each line which has led to the rendered markdown looking a little odd. This PR resolves that issue.