### PR TITLE
Update SPIFFE codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 ## SPIFFE Maintainers
 ##
 
-*  @arndt-s @justinburke @spikecurtis @azdagron
+*  @arndt-s @spikecurtis @strideynet @azdagron
 
 /CODE-OF-CONDUCT.md @spiffe/ssc
 /GOVERNANCE.md      @spiffe/ssc


### PR DESCRIPTION
Hi all, the time has come for me to pass the SPIFFE codeowners torch to a new steward.

After having joined the SPIFFE community back in 2017, I had an opportunity to 
work with some fantastic engineers as we hammered out specifications to support
cross-organization workload identity exchange. I'm proud of the work that we 
accomplished, thank you for welcoming me in as part of the SPIFFE community. 

However, it's been quite some time since I've been actively engaged in this
space. It's time for a trusted active member of the community to be recognized
for their contributions and committment.

I'm happy to propose that Noah Stride (@strideynet) replace me as a SPIFFE 
codeowner. Noah's dedication and expertise in workload identity is evident
through his participation in SIG-Spec meetings, contributions to code reviews 
and new profile specs, and hands-on implementation work. I believe that Noah is
excited by the challenge and opportunity for advancing the state of the art for
workload identity and will a careful, thoughtful, and inclusive steward for
SPIFFE going forward.

Please join me in welcoming Noah in this new role.

Justin

/cc @azdagron @spikecurtis @arndt-s 