### PR TITLE
Add "SPIFFE Federation" to main "SPIFFE" standard appendix

### DIFF
--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -58,3 +58,4 @@ This document covered, at a high level, the various components that make up the 
 * [The SPIFFE Workload Endpoint](SPIFFE_Workload_Endpoint.md)
 * [The SPIFFE Workload API](SPIFFE_Workload_API.md)
 * [The SPIFFE Trust Domain and Bundle](SPIFFE_Trust_Domain_and_Bundle.md)
+* [SPIFFE Federation](SPIFFE_Federation.md)


### PR DESCRIPTION
The main SPIFFE standard includes an appendix which links to all the other standards within SPIFFE. The SPIFFE Federation standard was missing from this list. This PR corrects that.