### PR TITLE
WIT-SVID Draft: Prohibit inclusion of `aud` claim

### DIFF
--- a/standards/WIT-SVID.md
+++ b/standards/WIT-SVID.md
@@ -186,6 +186,8 @@ Within SPIFFE, there already exists mechanisms for the distribution of trust bun
 
 ### 3.8. Additional Claims
 
+The audience (`aud`) claim MUST NOT be included within a WIT-SVID. The inclusion of this claim within the WIT-SVID is not appropriate as scoping authentication to a specific recipient should be implemented within the Proof of Possession and not the WIT itself.
+
 It is permitted for an implementation to include additional claims not specified in this document or the upstream document.
 
 When encountering additional claims that it does not recognize, a validator SHOULD ignore them.
@@ -333,6 +335,7 @@ Claim             | WIT-SVID | WIMSE WIT
 `iat`             | ~        | ~
 `nbf`             | ~        | ~
 `iss`             | ~*       | ~
+`aud`             | ✗        | ~
 Additional claims | ~        | ~
 
 Notes:


### PR DESCRIPTION
Closes https://github.com/spiffe/spiffe/issues/370

Since we expect the Proof of Possession mechanism to be used to scope to a specific recipient, there is no purpose to the `aud` claim being included within the WIT itself - and allowing it creates a scenario where validators would need to determine how to behave if `aud` within the WIT and the PoP disagreed.