### PR TITLE
Correct JSON Schema for JWT SVID

### DIFF
--- a/standards/JWT-SVID.schema
+++ b/standards/JWT-SVID.schema
@@ -39,6 +39,7 @@ properties:
           - "JOSE"
     required:
       - "alg"
+    additionalProperties: false
   payload:
     type: "object"
     properties:
@@ -50,7 +51,12 @@ properties:
           See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#31-subject
           This claim is REQUIRED.
       aud:
-        type: "string"
+        oneOf:
+          - type: "string"
+          - type: "array"
+            items:
+              type: "string"
+            minItems: 1
         description: |
           The "aud" (audience) claim as defined in RFC 7519.
           See https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#32-audience


### PR DESCRIPTION
Thanks to @geeknik of Deep Fork Cyber for reporting this issue.

This PR updates two elements of the JSON schema.

For the `header` property, I have added `additionalProperties: false`. This is to reflect the following from the specification:

> Any header not described here, registered or private, MUST NOT be included in the JWT-SVID JOSE Header.

To the `aud` claim, I have added a `oneof` to allow the value to either be a string, or an array of strings (minimum 1 item). This better reflects the common structure of `aud` within JWTs and JWT-SVIDs, and the following from the specification:

> The `aud` claim MUST be present, containing one or more values.

I'm not convinced that this schema file is in common usage - or at least it is not leveraged within any of the core SDKs. It also doesn't seem overly correct with `header` and `payload` as two properties of the same object - so I'm not sure that this could be in use by anybody without some gymnastics. Perhaps we should review this in the near future?