### PR TITLE
Propose a SPIFFE Filesystem Delivery standard

### DIFF
--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -1,0 +1,354 @@
+# The SPIFFE Filesystem Delivery Standard
+
+## Status of this Memo {#memo-status}
+
+This document specifies an identity API standard for the internet community, and
+requests discussion and suggestions for improvements. Distribution of this
+document is unlimited.
+
+## Abstract {#abstract}
+
+Many applications run in environments where SPIFFE certificates and trust
+bundles are more easily delivered via the filesystem, rather than the SPIFFE
+Workload API.  This specification gives applications and identity provisioning
+systems a concrete target to aim for:
+* How identity provisioning systems should write SPIFFE SVIDs.
+* How identity provisioning systems should write SPIFFE trust bundles for the
+  local and any federated trust domains.
+* Where applications should look to discover these credentials.
+* How applications should read them.
+
+As a concrete target, all of the features required by this specification are
+natively available in Kubernetes using the Pod Certificates and Cluster Trust
+Bundles features.
+
+## Table of Contents {#toc}
+
+1\. [Participants](#participants)
+2\. [Credential Folder](#credential-folder)
+2\.1\. [Credential Bundle](#credential-bundle)
+2\.2\. [SPIFFE Trust Bundles](#spiffe-trust-bundles)
+3\. [Application Behavior](#application-behavior)
+3\.1\. [Locating the Credential Folder](#locating-the-credential-folder)
+3\.2\. [Loading and Refreshing the Credential Bundle](#loading-and-refreshing-the-credential-bundle)
+3\.3\. [Validating Peer SPIFFE Certificates](#validating-peer-spiffe-certificates)
+Appendix A. [Filesystem Delivery and the Workload API](#appendix-filesystem-delivery-vs-the-workload-api)
+Appendix B. [Example Kubernetes Setup](#appendix-example-kubernetes-setup)
+
+
+## 1. Participants {#participants}
+
+**Provisioning System:** The software stack responsible for distributing X.509
+SVIDS and trust domain federation configuration to individual applications.
+
+For applications running in a Kubernetes cluster, this might be composed of
+kubelet, kube-apiserver, and a SPIFFE signer plugin, working through the Pod
+Certificates mechanism to deliver certificates into individual application pod
+filesystems.
+
+For applications running directly on a machine or VM, this may be a system
+daemon or node agent that writes X.509 SVIDs to a particular folder in the
+filesystem.
+
+**Application:** An individual application that expects to:
+* Load an X.509 SVID from the filesystem, and use it to connect to other peers.
+* Verify X.509 SVIDs presented by peers, including peers in different trust
+  domains.
+
+## 2. Credential Folder {#credential-folder}
+
+A credential folder contains:
+* A single credential bundle, named `credential-bundle.pem`
+* One or more trust bundles, named `<trust-domain>.spiffe-trust-bundle.pem`
+
+A credential folder MAY contain other files and directories, used by the
+provisioning system to track state and atomically update the credentials.  The
+application SHOULD ignore this additional content unless it is coordinated with
+the provisioning system to understand the content's meaning.
+
+Note that a credential folder carries only a single SPIFFE X.509 SVID.  If a
+provisioning system wants to provide multiple SPIFFE identities to an
+application, it must provide multiple SPIFFE credential folders, and only one of
+those folders can appear at the default well-known path.  The provisioning
+system and application must be coordinated so that the application knows where
+to find the alternate credential folders, and in which circumstances they should
+be used.
+
+### 2.1 Credential Bundle {#credential-bundle}
+
+A credential bundle file contains the application's private key and certificate
+chain.  Combining these together into one file ensures that the provisioning
+system can rotate the key and certificate atomically.  (Note that, for safety,
+the application must also read this file atomically, as described in section
+3.2).
+
+The credential bundle consists of two or more PEM blocks.  The first block must
+be of type PRIVATE KEY, and contain a PKCS#8-serialized private key.
+
+The remaining PEM blocks must be of type CERTIFICATE, and contain the
+application's certificate chain, in leaf-to-root order.  The leaf certificate
+must be issued to the public key derived from the PRIVATE KEY block.  The leaf
+certificate SHOULD be an X.509 SVID.
+
+The certificate chain MAY contain the trust anchor ("root certificate") of the
+chain, or it MAY stop at the certificate preceding the trust anchor.
+
+The credential bundle:
+* MUST NOT contain any other PEM block types.
+* MUST NOT contain any inter-block data.
+* MUST NOT contain any PEM blocks that have PEM headers.
+
+The provisioning system SHOULD update the credential bundle on the filesystem
+with a new key and certificate chain before the leaf certificate currently in
+the bundle expires. The provisioning system SHOULD make these updates
+atomically, so that an application reading the credential bundle reads either
+the complete old content or the complete new content, with no intermediate
+state.
+
+The developer SHOULD NOT copy this file anywhere, since compromise of the
+credential-bundle.pem file could compromise the security of TLS sessions. The
+provisioning system SHOULD be configured to limit access to the
+credential-bundle.pem file to only the necessary user(s).
+
+### 2.2 SPIFFE Trust Bundles {#spiffe-trust-bundles}
+
+The credential folder will contain one or more trust bundles, one per trust
+domain that the provisioning system is configured to federate with.
+
+Each trust bundle file MUST be named following the pattern
+"<trust-domain>.spiffe-trust-bundle.pem".  The file contents are one or more PEM
+CERTIFICATE blocks, each with a PKIX-serialized certificate that is a trust
+anchor for the trust domain.  In most cases, a trust anchor is a root
+certificate, although in rare cases it may be an intermediate certificate.
+
+A trust bundle file:
+* MUST NOT contain any other PEM block types.
+* MUST NOT contain any inter-block data.
+* MUST NOT contain any PEM blocks that have PEM headers.
+
+The provisioning system SHOULD update the trust bundles on the filesystem as the
+system's federation configuration changes.  The provisioning system SHOULD make
+these updates atomically, so that an application reading a trust bundle reads
+either the complete old content, or the complete new content, with no
+intermediate state.
+
+The certificates in a SPIFFE trust bundle file should only be used by
+SPIFFE-aware applications.  It is not generally safe to attempt to use any of
+these certificates for standard server TLS certificate verification.  In
+particular, it is *never* safe to combine the contents of more than one SPIFFE
+trust bundle into a single, undifferentiated bag of root certificates.
+
+## 3. Application Behavior {#application-behavior}
+
+### 3.1 Locating the Credential Folder {#locating-the-credential-folder}
+The application SHOULD search for a SPIFFE credential folder with the following
+procedure:
+1. The application should first follow the procedure from [SPIFFE Workload
+   Endpoint, Section
+   4](https://spiffe.io/docs/latest/spiffe-specs/spiffe_workload_endpoint/#4-locating-the-endpoint)
+   to determine if the SPIFFE Workload API is available.
+2. If the applications supports an application-specific configuration mechanism
+   for picking a SPIFFE credential folder, it use the credential folder
+   indicated by that configuration.
+3. Otherwise, if the SPIFFE_CREDENTIAL_FOLDER environment variable is set, and
+   contains a valid path for the platform, the application should treat that
+   folder as the credential folder to use.
+4. Otherwise, the application should check for the existence of a
+   platform-specific default credential folder, and use it if it is present.
+5. Otherwise, the application has not been issued SPIFFE credentials.
+
+On platforms that use the Filesystem Hierarchy Standard, such as Linux, the
+application should check the following default credential folders, in descending
+order of preference:
+1) `/run/secrets/workload-spiffe-credentials/credential-bundle.pem`
+2) `/var/run/secrets/workload-spiffe-credentials/credential-bundle.pem`
+  
+On most systems, `/var/run` is a symlink to `/run`, or vice-versa.  However this
+may not be true in some containerized environments, especially those that use
+distroless base images.
+
+### 3.2 Loading and Refreshing the Credential Bundle {#loading-and-refreshing-the-credential-bundle}
+
+Before the application can use its SPIFFE credentials, it needs to load the
+credential bundle from the filesystem.
+
+When loading the credential bundle, the application SHOULD complete the load in
+a single open/read/close cycle.  In particular, the application SHOULD NOT have
+one open/read/close cycle to read the private key, and another open/read/close
+cycle to read the certificate chain.
+
+Note: If the application does use more than one open/read/close cycle, then it
+is possible that the application may load a mismatched private key and
+certificate, if the provisioning system rotated the credentials between the two
+open/read/close cycles.  This is true even if the provisioning system atomically
+writes the updated content.
+
+The provisioning system may periodically update the credential bundle on the
+filesystem.  The application SHOULD reload the credential bundle as soon as
+reasonably possible after the provisioning system updating it.  The application
+SHOULD NOT assume that the updated bundle will have any commonality with the
+previous bundle.  For example, the type of the private key may be different, or
+the certificate may be issued from a different root, with different
+intermediates.
+
+### 3.3 Validating Peer SPIFFE Certificates {#validating-peer-spiffe-certificates}
+
+In order to verify a SPIFFE X.509 SVID presented by a peer, the application
+needs to determine the correct SPIFFE trust bundle for the peer's trust domain.
+
+Once the application has parsed the peer's trust domain from the unverified peer
+X.509 SVID, the application should load the corresponding trust domain's
+trust bundle from the credential folder.  If no trust bundle file is present for
+the peer's trust domain, the application SHOULD assume that SPIFFE federation
+has not been configured with the peer, and fail to verify the peer's
+certificate.
+
+The provisioning system may periodically update the number and contents of the
+per-trust-domain trust bundles in the filesystem.  The application MAY cache the
+presence, absence, and contents of each trust domain's trust bundle in memory,
+but it SHOULD reflect updates from the filesystem as soon as reasonably
+possible.
+
+The application SHOULD handle de-federation; if it has loaded a trust bundle for
+trust domain X, and then X's trust bundle is removed from the credential folder,
+the application SHOULD begin failing to verify certificates for trust domain X
+as soon as reasonably possible.  This only needs to affect new TLS handshakes;
+established TLS connections may remain open until they are otherwise finished or
+interrupted.
+
+As mentioned in section 2.2, it is not safe to use the contents of a SPIFFE
+trust bundle file except by a SPIFFE-aware application performing SPIFFE X.509
+SVID verification for a certificate from the corresponding trust domain.
+Applications should NEVER unify the contents of multiple
+`*.spiffe-trust-bundle.pem` files into a single root store for certificate
+verification, including by treating the entire SPIFFE credential folder as a
+root certificate store.
+
+## Appendix A: Filesystem Delivery Versus the Workload API {#filesystem-delivery-vs-the-workload-api}
+
+There are currently two standards for SPIFFE-conforming applications to retrieve
+credentials and trust bundles: the Workload API, and Filesystem Delivery.  These
+standards, broadly speaking, cover the same functionality.  The Workload API
+predates Filesystem Delivery, and is the preferred solution, all else equal.
+
+Filesystem Delivery exists because, in certain computing environments, such as
+Kubernetes, it is easier for the environment to furnish *files* to the workload,
+rather than making a TCP or Unix socket service available.  It's also lower
+effort to read files from workloads, but, as described in [Section
+3.2](#loading-and-refreshing-the-credential-bundle), it still requires care.
+
+Given these two choices, which should you use?
+
+If you are writing or maintaining an application that needs to load and use
+SPIFFE credentials, you should ideally support both the Workload API and
+Filesystem Delivery, following the procedure from [Section
+3.1](#locating-the-credential-folder) to select.
+
+If supporting both is not feasible, then consider which standard the SPIFFE
+identity provisioning you are most likely to use supports.
+
+If you are writing or maintaining a SPIFFE X.509 identity provisioning system,
+then, again, ideally you would support both mechanisms, however (as in the case
+of Kubernetes) the Workload API may be less feasible.
+
+## Appendix B: Example Kubernetes Setup {#example-kubernetes-setup}
+
+Kubernetes provides two built-in mechanisms that can be used together to
+implement the SPIFFE Filesystem Delivery API:
+* Pod Certificates are a pluggable mechanism to issue and automatically refresh
+  certificates to application pods.  Each pod gets an independent private key,
+  which never leaves the node where the pod is running.  The private key and
+  certificate chain can be written into a credential bundle in the pod's
+  filesystem.
+* Cluster Trust Bundles are bags of root certificates with a unique name.  They
+  can be mounted into a pod's filesystem, and the content in the filesystem
+  automatically updates as the Cluster Trust Bundles are updated.
+
+For example, we could implement a controller that handles the signer name
+`spiffe.example/identity`.  This controller would have two responsibilities:
+* Respond to PodCertificateRequests from pods that want a certificate from the
+  `spiffe.example/identity`.  The precise details of the issued certificate are
+  up to the controller.  In this case, assume that it is configured to issue
+  certificates with SPIFFE IDs like
+  `spiffe://domain-a.myorg.example/ns/<namespace>/sa/<service-account>`.
+* Maintain a set of ClusterTrustBundles associated with
+  `spiffe.example/identity`.  There are many potential ways to structure the set
+  of ClusterTrustBundles, but one that would work is to use labels to divide
+  them:
+    * `k8s.spiffe.io/canarying`: Possible values of `live` or `preview`.  Most
+      application pods would always select ClusterTrustBundles with the value
+      `live`, but some may be configured to select `preview`, so that actions
+      like rotating a CA or federating with a new trust domain can be previewed
+      on some fraction of your application fleet.
+    * `k8s.spiffe.io/workload-trust-domain`:  The label's value is a trust
+      domain X; workloads that are part of X should load this trust bundle.
+    * `k8s.spiffe.io/peer-trust-domain`: The label's value is a trust domain Y;
+      workloads that are communicating with a peer in Y should load this trust
+      bundle.
+
+Note: Drawing a distinction between a *workload's* trust domain and its *peer's*
+trust domain is necessary (but non-obvious) when workloads from multiple trust
+domains can be mixed together in one cluster.  Each trust domain should have its
+own federation configuration; given three trust domains A, B, and C, if A is
+federated with C, workloads in B should not automatically also be federated just
+because they happen to run in the same Kubernetes cluster.
+
+This information can then be mounted into an application pod in a way that forms
+a valid SPIFFE credential folder:
+
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  namespace: spiffe-example
+  labels:
+    app: client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: client
+        image: debian
+        command: ["sleep", "infinity"]
+        volumeMounts:
+        - name: default-spiffe-credentials
+          mountPath: /run/workload-spiffe-credentials
+          readOnly: true
+      volumes:
+      - name: default-spiffe-credentials
+        projected:
+          sources:
+          - clusterTrustBundle:
+              signerName: spiffe.example/identity
+              labelSelector:
+                matchLabels:
+                  "k8s.spiffe.io/canarying":             "live"
+                  "k8s.spiffe.io/workload-trust-domain": "a.myorg.example"
+                  "k8s.spiffe.io/peer-trust-domain":     "a.myorg.example"
+              path: a.myorg.example.spiffe-trust-bundle.pem
+          # This workload needs to federate with b.myorg.example, so it needs the appropriate bundle.
+          - clusterTrustBundle:
+              signerName: spiffe.example/identity
+              labelSelector:
+                matchLabels:
+                  "k8s.spiffe.io/canarying":             "live"
+                  "k8s.spiffe.io/workload-trust-domain": "a.myorg.example"
+                  "k8s.spiffe.io/peer-trust-domain":     "b.myorg.example"
+              path: b.myorg.example.spiffe-trust-bundle.pem
+          - podCertificate:
+              signerName: spiffe.example/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem
+```
+
+
+

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -1,0 +1,355 @@
+# The SPIFFE Filesystem Delivery Standard
+
+## Status of this Memo {#memo-status}
+
+This document specifies an identity API standard for the internet community, and
+requests discussion and suggestions for improvements. Distribution of this
+document is unlimited.
+
+## Abstract {#abstract}
+
+Many applications run in environments where SPIFFE certificates and trust
+bundles are more easily delivered via the filesystem, rather than the SPIFFE
+Workload API.  This specification gives applications and identity provisioning
+systems a concrete target to aim for:
+* How identity provisioning systems should write SPIFFE SVIDs.
+* How identity provisioning systems should write SPIFFE trust bundles for the
+  local and any federated trust domains.
+* Where applications should look to discover these credentials.
+* How applications should read them.
+
+As a concrete target, all of the features required by this specification are
+natively available in Kubernetes using the Pod Certificates and Cluster Trust
+Bundles features.
+
+## Table of Contents {#toc}
+
+1\. [Participants](#participants)
+2\. [Credential Folder](#credential-folder)
+2\.1\. [Credential Bundle](#credential-bundle)
+2\.2\. [SPIFFE Trust Bundles](#spiffe-trust-bundles)
+3\. [Application Behavior](#application-behavior)
+3\.1\. [Locating the Credential Folder](#locating-the-credential-folder)
+3\.2\. [Loading and Refreshing the Credential Bundle](#loading-and-refreshing-the-credential-bundle)
+3\.3\. [Validating Peer SPIFFE Certificates](#validating-peer-spiffe-certificates)
+Appendix A. [Filesystem Delivery and the Workload API](#appendix-filesystem-delivery-vs-the-workload-api)
+Appendix B. [Example Kubernetes Setup](#appendix-example-kubernetes-setup)
+
+
+## 1. Participants {#participants}
+
+**Provisioning System:** The software stack responsible for distributing X.509
+SVIDS and trust domain federation configuration to individual applications.
+
+For applications running in a Kubernetes cluster, this might be composed of
+kubelet, kube-apiserver, and a SPIFFE signer plugin, working through the Pod
+Certificates mechanism to deliver certificates into individual application pod
+filesystems.
+
+For applications running directly on a machine or VM, this may be a system
+daemon or node agent that writes X.509 SVIDs to a particular folder in the
+filesystem.
+
+**Application:** An individual application that expects to:
+* Load an X.509 SVID from the filesystem, and use it to connect to other peers.
+* Verify X.509 SVIDs presented by peers, including peers in different trust
+  domains.
+
+## 2. Credential Folder {#credential-folder}
+
+A credential folder contains:
+* A single credential bundle, named `credential-bundle.private-key.pem`
+* One or more trust bundles, named `<trust-domain>.spiffe-trust-bundle.pem`
+
+A credential folder MAY contain other files and directories, used by the
+provisioning system for internal tracking or platform-specific features.  The
+application SHOULD ignore this additional content unless it is coordinated with
+the provisioning system to understand the content's meaning.
+
+Note that a credential folder carries only a single SPIFFE X.509 SVID.  If a
+provisioning system wants to provide multiple SPIFFE identities to an
+application, it must provide multiple SPIFFE credential folders.  The
+provisioning system and application must be coordinated so that the application
+knows where to find the additional credential folders, and in which
+circumstances they should be used.
+
+### 2.1 Credential Bundle {#credential-bundle}
+
+A credential bundle file contains the application's private key and certificate
+chain.  Combining these together into one file ensures that the provisioning
+system can rotate the key and certificate atomically.  (Note that, for safety,
+the application must also read this file atomically, as described in section
+3.2).
+
+The credential bundle consists of two or more PEM blocks.  The first block must
+be of type PRIVATE KEY, and contain a PKCS#8-serialized private key.
+
+Compatibility Note: Some provisioning systems offer features for keeping the
+private key inaccessible to the application, only exposing RPCs for signing
+operations over the private key.  When a feature like this is in use, the
+credential bundle might omit the private key.  The provisioning system and
+application must be coordinated to make this happen.  SPIFFE-compliant
+applications are not required to seamlessly handle this case.
+
+The remaining PEM blocks must be of type CERTIFICATE, and contain the
+application's certificate chain, in leaf-to-root order.  The leaf certificate
+must be issued to the public key derived from the PRIVATE KEY block.  The leaf
+certificate SHOULD be an X.509 SVID.
+
+The certificate chain MAY contain the trust anchor ("root certificate") of the
+chain, or it MAY stop at the certificate preceding the trust anchor.
+
+The credential bundle:
+* MUST NOT contain any other PEM block types.
+* MUST NOT contain any inter-block data.
+* MUST NOT contain any PEM blocks that have PEM headers.
+
+The provisioning system SHOULD update the credential bundle on the filesystem
+with a new key and certificate chain before the leaf certificate currently in
+the bundle expires. The provisioning system SHOULD make these updates
+atomically, so that an application reading the credential bundle reads either
+the complete old content or the complete new content, with no intermediate
+state.
+
+The developer SHOULD NOT copy this file anywhere, since compromise of the
+credential-bundle.private-key.pem file could compromise the security of TLS
+sessions. The provisioning system SHOULD be configured to limit access to the
+credential-bundle.private-key.pem file to only the necessary user(s).
+
+### 2.2 SPIFFE Trust Bundles {#spiffe-trust-bundles}
+
+The credential folder will contain one or more trust bundles, one per trust
+domain that the provisioning system is configured to federate with.
+
+Each trust bundle file MUST be named following the pattern
+"<trust-domain>.spiffe-trust-bundle.pem".  The file contents are one or more PEM
+CERTIFICATE blocks, each with a PKIX-serialized certificate that is a trust
+anchor for the trust domain.  In most cases, a trust anchor is a root
+certificate, although in rare cases it may be an intermediate certificate.
+
+A trust bundle file:
+* MUST NOT contain any other PEM block types.
+* MUST NOT contain any inter-block data.
+* MUST NOT contain any PEM blocks that have PEM headers.
+
+The provisioning system SHOULD update the trust bundles on the filesystem as the
+system's federation configuration changes.  The provisioning system SHOULD make
+these updates atomically, so that an application reading a trust bundle reads
+either the complete old content, or the complete new content, with no
+intermediate state.
+
+The certificates in a SPIFFE trust bundle file should only be used by
+SPIFFE-aware applications.  It is not generally safe to attempt to use any of
+these certificates for standard server TLS certificate verification.  In
+particular, it is *never* safe to combine the contents of more than one SPIFFE
+trust bundle into a single, undifferentiated bag of root certificates.
+
+## 3. Application Behavior {#application-behavior}
+
+### 3.1 Locating the Credential Folder {#locating-the-credential-folder}
+The application SHOULD search for a SPIFFE credential folder with the following
+procedure:
+1. The application should first follow the procedure from [SPIFFE Workload
+   Endpoint, Section
+   4](https://spiffe.io/docs/latest/spiffe-specs/spiffe_workload_endpoint/#4-locating-the-endpoint)
+   to determine if the SPIFFE Workload API is available.
+2. If the application supports an application-specific configuration mechanism
+   for picking a SPIFFE credential folder, it should use the credential folder
+   indicated by that configuration.
+3. Otherwise, if the SPIFFE_CREDENTIAL_FOLDER environment variable is set, and
+   contains a valid path for the platform, the application should treat that
+   folder as the credential folder to use.
+4. Otherwise, the application has not been issued SPIFFE credentials.
+
+This specification does not define a default or well-known location for the
+credential folder.
+
+### 3.2 Loading and Refreshing the Credential Bundle {#loading-and-refreshing-the-credential-bundle}
+
+Before the application can use its SPIFFE credentials, it needs to load the
+credential bundle from the filesystem.
+
+When loading the credential bundle, the application SHOULD complete the load in
+a single open/read/close cycle.  In particular, the application SHOULD NOT have
+one open/read/close cycle to read the private key, and another open/read/close
+cycle to read the certificate chain.
+
+Note: If the application does use more than one open/read/close cycle, then it
+is possible that the application may load a mismatched private key and
+certificate, if the provisioning system rotated the credentials between the two
+open/read/close cycles.  This is true even if the provisioning system atomically
+writes the updated content.
+
+The provisioning system may periodically update the credential bundle on the
+filesystem.  The application SHOULD reload the credential bundle as soon as
+reasonably possible after the provisioning system updating it.  The application
+SHOULD NOT assume that the updated bundle will have any commonality with the
+previous bundle.  For example, the type of the private key may be different, or
+the certificate may be issued from a different root, with different
+intermediates.
+
+### 3.3 Validating Peer SPIFFE Certificates {#validating-peer-spiffe-certificates}
+
+In order to verify a SPIFFE X.509 SVID presented by a peer, the application
+needs to determine the correct SPIFFE trust bundle for the peer's trust domain.
+
+Once the application has parsed the peer's trust domain from the unverified peer
+X.509 SVID, the application should load the corresponding trust domain's
+trust bundle from the credential folder.  If no trust bundle file is present for
+the peer's trust domain, the application SHOULD assume that SPIFFE federation
+has not been configured with the peer, and fail to verify the peer's
+certificate.
+
+The provisioning system may periodically update the number and contents of the
+per-trust-domain trust bundles in the filesystem.  The application MAY cache the
+presence, absence, and contents of each trust domain's trust bundle in memory,
+but it SHOULD reflect updates from the filesystem as soon as reasonably
+possible.
+
+The application SHOULD handle de-federation; if it has loaded a trust bundle for
+trust domain X, and then X's trust bundle is removed from the credential folder,
+the application SHOULD begin failing to verify certificates for trust domain X
+as soon as reasonably possible.  This only needs to affect new TLS handshakes;
+established TLS connections may remain open until they are otherwise finished or
+interrupted.
+
+As mentioned in section 2.2, it is not safe to use the contents of a SPIFFE
+trust bundle file except by a SPIFFE-aware application performing SPIFFE X.509
+SVID verification for a certificate from the corresponding trust domain.
+Applications should NEVER unify the contents of multiple
+`*.spiffe-trust-bundle.pem` files into a single root store for certificate
+verification, including by treating the entire SPIFFE credential folder as a
+root certificate store.
+
+## Appendix A: Filesystem Delivery Versus the Workload API {#filesystem-delivery-vs-the-workload-api}
+
+There are currently two standards for SPIFFE-conforming applications to retrieve
+credentials and trust bundles: the Workload API, and Filesystem Delivery.  These
+standards, broadly speaking, cover the same functionality.  The Workload API
+predates Filesystem Delivery, and is the preferred solution, all else equal.
+
+Filesystem Delivery exists because, in certain computing environments, such as
+Kubernetes, it is easier for the environment to furnish *files* to the workload,
+rather than making a TCP or Unix socket service available.  It's also lower
+effort to read files from workloads, but, as described in [Section
+3.2](#loading-and-refreshing-the-credential-bundle), it still requires care.
+
+Given these two choices, which should you use?
+
+If you are writing or maintaining an application that needs to load and use
+SPIFFE credentials, you should ideally support both the Workload API and
+Filesystem Delivery, following the procedure from [Section
+3.1](#locating-the-credential-folder) to select.
+
+If supporting both is not feasible, then consider which standard the SPIFFE
+identity provisioning you are most likely to use supports.
+
+If you are writing or maintaining a SPIFFE X.509 identity provisioning system,
+then, again, ideally you would support both mechanisms, however (as in the case
+of Kubernetes) the Workload API may be less feasible.
+
+## Appendix B: Example Kubernetes Setup {#example-kubernetes-setup}
+
+Kubernetes provides two built-in mechanisms that can be used together to
+implement the SPIFFE Filesystem Delivery API:
+* Pod Certificates are a pluggable mechanism to issue and automatically refresh
+  certificates to application pods.  Each pod gets an independent private key,
+  which never leaves the node where the pod is running.  The private key and
+  certificate chain can be written into a credential bundle in the pod's
+  filesystem.
+* Cluster Trust Bundles are bags of root certificates with a unique name.  They
+  can be mounted into a pod's filesystem, and the content in the filesystem
+  automatically updates as the Cluster Trust Bundles are updated.
+
+For example, we could implement a controller that handles the signer name
+`spiffe.example/identity`.  This controller would have two responsibilities:
+* Respond to PodCertificateRequests from pods that want a certificate from the
+  `spiffe.example/identity`.  The precise details of the issued certificate are
+  up to the controller.  In this case, assume that it is configured to issue
+  certificates with SPIFFE IDs like
+  `spiffe://domain-a.myorg.example/ns/<namespace>/sa/<service-account>`.
+* Maintain a set of ClusterTrustBundles associated with
+  `spiffe.example/identity`.  There are many potential ways to structure the set
+  of ClusterTrustBundles, but one that would work is to use labels to divide
+  them:
+    * `k8s.spiffe.io/canarying`: Possible values of `live` or `preview`.  Most
+      application pods would always select ClusterTrustBundles with the value
+      `live`, but some may be configured to select `preview`, so that actions
+      like rotating a CA or federating with a new trust domain can be previewed
+      on some fraction of your application fleet.
+    * `k8s.spiffe.io/workload-trust-domain`:  The label's value is a trust
+      domain X; workloads that are part of X should load this trust bundle.
+    * `k8s.spiffe.io/peer-trust-domain`: The label's value is a trust domain Y;
+      workloads that are communicating with a peer in Y should load this trust
+      bundle.
+
+Note: Drawing a distinction between a *workload's* trust domain and its *peer's*
+trust domain is necessary (but non-obvious) when workloads from multiple trust
+domains can be mixed together in one cluster.  Each trust domain should have its
+own federation configuration; given three trust domains A, B, and C, if A is
+federated with C, workloads in B should not automatically also be federated just
+because they happen to run in the same Kubernetes cluster.
+
+This information can then be mounted into an application pod in a way that forms
+a valid SPIFFE credential folder, with the SPIFFE_CREDENTIAL_FOLDER environment
+variable pointing the application at the mount path:
+
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  namespace: spiffe-example
+  labels:
+    app: client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: client
+        image: debian
+        command: ["sleep", "infinity"]
+        env:
+        - name: SPIFFE_CREDENTIAL_FOLDER
+          value: /run/workload-spiffe-credentials
+        volumeMounts:
+        - name: spiffe-credentials
+          mountPath: /run/workload-spiffe-credentials
+          readOnly: true
+      volumes:
+      - name: spiffe-credentials
+        projected:
+          sources:
+          - clusterTrustBundle:
+              signerName: spiffe.example/identity
+              labelSelector:
+                matchLabels:
+                  "k8s.spiffe.io/canarying":             "live"
+                  "k8s.spiffe.io/workload-trust-domain": "a.myorg.example"
+                  "k8s.spiffe.io/peer-trust-domain":     "a.myorg.example"
+              path: a.myorg.example.spiffe-trust-bundle.pem
+          # This workload needs to federate with b.myorg.example, so it needs the appropriate bundle.
+          - clusterTrustBundle:
+              signerName: spiffe.example/identity
+              labelSelector:
+                matchLabels:
+                  "k8s.spiffe.io/canarying":             "live"
+                  "k8s.spiffe.io/workload-trust-domain": "a.myorg.example"
+                  "k8s.spiffe.io/peer-trust-domain":     "b.myorg.example"
+              path: b.myorg.example.spiffe-trust-bundle.pem
+          - podCertificate:
+              signerName: spiffe.example/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem
+```
+
+
+

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -248,13 +248,6 @@ SPIFFE credentials, you should ideally support both the Workload API and
 Filesystem Delivery, following the procedure from [Section
 3.1](#locating-the-credential-folder) to select.
 
-If supporting both is not feasible, then consider which standard the SPIFFE
-identity provisioning you are most likely to use supports.
-
-If you are writing or maintaining a SPIFFE X.509 identity provisioning system,
-then, again, ideally you would support both mechanisms, however (as in the case
-of Kubernetes) the Workload API may be less feasible.
-
 ## Appendix B: Example Kubernetes Setup {#example-kubernetes-setup}
 
 Kubernetes provides two built-in mechanisms that can be used together to

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -110,10 +110,11 @@ The credential bundle:
 
 The provisioning system SHOULD update the credential bundle on the filesystem
 with a new key and certificate chain before the leaf certificate currently in
-the bundle expires. The provisioning system SHOULD make these updates
-atomically, so that an application reading the credential bundle reads either
-the complete old content or the complete new content, with no intermediate
-state.
+the bundle expires, with enough additional time for the application to detect
+and reload the updated credential bundle. The provisioning system SHOULD make
+these updates atomically, so that an application reading the credential bundle
+reads either the complete old content or the complete new content, with no
+intermediate state.
 
 The developer SHOULD NOT copy this file anywhere, since compromise of the
 credential-bundle.private-key.pem file could compromise the security of TLS

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -73,6 +73,10 @@ provisioning system and application must be coordinated so that the application
 knows where to find the additional credential folders, and in which
 circumstances they should be used.
 
+Because the credential folder contains sensitive credentials, provisioning
+systems SHOULD ensure that their contents do not appear on physical disks or in
+automatic backups.
+
 ### 2.1 Credential Bundle {#credential-bundle}
 
 A credential bundle file contains the application's private key and certificate

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -100,8 +100,8 @@ application's certificate chain, in leaf-to-root order.  The leaf certificate
 must be issued to the public key derived from the PRIVATE KEY block.  The leaf
 certificate SHOULD be an X.509 SVID.
 
-The certificate chain MAY contain the trust anchor ("root certificate") of the
-chain, or it MAY stop at the certificate preceding the trust anchor.
+The certificate chain MUST NOT contain the trust anchor ("root certificate") of
+the chain.  It MUST stop at the certificate preceding the trust anchor.
 
 The credential bundle:
 * MUST NOT contain any other PEM block types.

--- a/standards/SPIFFE_Filesystem_Delivery.md
+++ b/standards/SPIFFE_Filesystem_Delivery.md
@@ -188,10 +188,11 @@ writes the updated content.
 The provisioning system may periodically update the credential bundle on the
 filesystem.  The application SHOULD reload the credential bundle as soon as
 reasonably possible after the provisioning system updating it.  The application
-SHOULD NOT assume that the updated bundle will have any commonality with the
-previous bundle.  For example, the type of the private key may be different, or
-the certificate may be issued from a different root, with different
-intermediates.
+MUST reload the credential bundle within 5 minutes of an update on the
+filesystem.  The application SHOULD NOT assume that the updated bundle will have
+any commonality with the previous bundle.  For example, the type of the private
+key may be different, or the certificate may be issued from a different root,
+with different intermediates.
 
 ### 3.3 Validating Peer SPIFFE Certificates {#validating-peer-spiffe-certificates}
 
@@ -224,7 +225,8 @@ SVID verification for a certificate from the corresponding trust domain.
 Applications should NEVER unify the contents of multiple
 `*.spiffe-trust-bundle.pem` files into a single root store for certificate
 verification, including by treating the entire SPIFFE credential folder as a
-root certificate store.
+root certificate store.  Doing this allows for workloads in one trust domain to
+impersonate workloads in another trust domain.
 
 ## Appendix A: Filesystem Delivery Versus the Workload API {#filesystem-delivery-vs-the-workload-api}
 


### PR DESCRIPTION
Kubernetes has two new features that will be going GA in Kubernetes 1.37, Pod Certificates and Cluster Trust Bundles, which together form a pluggable mechanism for securely and conveniently distributing keys, certificates, and trust bundles to pod filesystems.

When applied to SPIFFE, these two mechanisms fill the same purpose as the SPIFFE Workload API, but accessed through the filesystem, rather than a Unix or TCP socket.

It would be beneficial for there to be a common standard for how the contents of these folders should be organized, to minimize the number of arbitrary choices that platforms and consumers need to make.