### PR TITLE
Nominate Aviral Garg for 2026H1 SSC Election

### DIFF
--- a/ssc/elections/2026H1/AVIRAL_GARG.md
+++ b/ssc/elections/2026H1/AVIRAL_GARG.md
@@ -1,0 +1,13 @@
+# Aviral Garg
+I'm a developer and researcher based out of New Delhi, and I co-founded a startup called Waysorted. I got into the CNCF world through contributing to projects like Meshery and Perses, and that's what eventually led me to SPIFFE. The more I dug into the identity and security side of cloud-native infrastructure, the more I realized how foundational SPIFFE really is to getting service-to-service trust right.
+
+My most recent contribution to the ecosystem has been on SPIRE -- I put together a PR that adds SPIFFE-backed TLS identity for Prometheus along with a configurable SPIFFE ID allowlist (spiffe/spire#6812). It came out of a real need I saw for tighter observability security in environments already using SPIFFE for identity.
+
+Outside of SPIFFE, I've built a few open-source tools of my own -- AgentUnit, which is a testing harness for AI agents, and NexumDB, a database that mixes SQL with some ML-based query optimization. I also spent time at DRDO earlier in my career working on secure systems, which shaped a lot of how I think about infrastructure and trust.
+
+I want to be on the SSC because I care about this project's direction and I think there's room to make SPIFFE's contributor experience better, especially for people coming in from outside the usual circles. I'd bring a cross-project perspective from working across multiple CNCF projects, and I'm genuinely committed to putting in the time this role needs.
+
+**GitHub Handle:** @aviralgarg05  
+**Email Address:** gargaviral99@gmail.com  
+**LinkedIn Profile:** https://www.linkedin.com/in/aviral-garg99  
+**Current Affiliation:** Waysorted (Co-Founder)


### PR DESCRIPTION
Self-nomination for the 2026 H1 SSC Election as tracked in #384.

I am an eligible participant as listed in the election tracking issue. This PR adds my nomination file to `ssc/elections/2026H1/AVIRAL_GARG.md` following the NOMINEE_TEMPLATE format.