### PR TITLE
Nominate Kevin Fox for 2026H1 SSC Election

### DIFF
--- a/ssc/elections/2026H1/KEVIN_FOX.md
+++ b/ssc/elections/2026H1/KEVIN_FOX.md
@@ -1,0 +1,8 @@
+# Kevin Fox
+
+Kevin Fox is one of the active contributors to multiple SPIFFE community projects. He is a top contributor to SPIRE Helm charts and has been instrumental in the development of the SPIRE Helm chart for Kubernetes. Kevin has been active community member and always willing to help others in the community. He has been a great advocate for SPIFFE and SPIRE and has very practical perspective on how to run it in bare-metal and air-gapped environments. Kevin has been a great asset to the SPIFFE community and has been a great help in the development of different SPIFFE projects.
+
+**GitHub Handle:** @kfox1111
+**Email Address:** kfox1111@gmail.com
+**LinkedIn Profile:** https://www.pnnl.gov/people/kevin-fox
+**Current Affiliation:** Pacific Northwest National Laboratory


### PR DESCRIPTION
Self-nomination for the 2026 H1 SSC Election as tracked in #384.

I am an eligible participant as listed in the election tracking issue. This PR adds my nomination file to ssc/elections/2026H1/KEVIN_FOX.md following the NOMINEE_TEMPLATE format.