### PR TITLE
Fix spelling, references, grammar across specifications

### DIFF
--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -18,6 +18,7 @@ For more general information about SPIFFE, please see the [Secure Production Ide
 2.1.1. [Trust Domain Name Collisions](#211-trust-domain-name-collisions)  
 2.2. [Path](#22-path)  
 2.3. [Maximum SPIFFE ID Length](#23-maximum-spiffe-id-length)  
+2.4. [SPIFFE ID Parsing](#24-spiffe-id-parsing)  
 3\. [SPIFFE Verifiable Identity Document](#3-spiffe-verifiable-identity-document)  
 3.1. [SVID Trust](#31-svid-trust)  
 3.2. [SVID Components](#32-svid-components)  

--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -4,7 +4,7 @@
 This document specifies an identity and identity issuance standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 
 ## Abstract
-Distributed design patterns and practices such as microservices, container orchestrators, and cloud computing have led to production environments that are increasingly dynamic and heterogenous. Conventional security practices (such as network policies that only allow traffic between particular IP addresses) struggle to scale under this complexity. A first-class identity framework for workloads in an organization becomes necessary.
+Distributed design patterns and practices such as microservices, container orchestrators, and cloud computing have led to production environments that are increasingly dynamic and heterogeneous. Conventional security practices (such as network policies that only allow traffic between particular IP addresses) struggle to scale under this complexity. A first-class identity framework for workloads in an organization becomes necessary.
 
 Further, modern developers are expected to understand and play a role in how applications are deployed and managed in production environments. Operations teams require deeper visibility into the applications they are managing. As we move to a more evolved security stance, we must offer better tools to both teams so they can play an active role in building secure, distributed applications.
 

--- a/standards/SPIFFE_Trust_Domain_and_Bundle.md
+++ b/standards/SPIFFE_Trust_Domain_and_Bundle.md
@@ -38,7 +38,7 @@ A SPIFFE trust domain is an identity namespace which is backed by an issuing aut
 
 Trust domains have a 1:N relationship with the keys that back them. A single trust domain may be represented by multiple keys and key types. For example, the former may be leveraged during root rotation, while the latter is necessary in avoiding multi-protocol attacks should more than one SVID type be in use.
 
-It should be noted that while it is possible to share cryptographic keys amongst many trust domains, we strongly advise that each authoritative key be used in a single trust domain. Key reuse can degrade trust domain isolation (e.g. between staging and production) and introduces additional security challenges (e.g. requiring a name constraint system for secondary issuers). Please see the [Security Considerations](#5-security-considerations) section for more information on this topic.
+It should be noted that while it is possible to share cryptographic keys amongst many trust domains, we strongly advise that each authoritative key be used in a single trust domain. Key reuse can degrade trust domain isolation (e.g. between staging and production) and introduces additional security challenges (e.g. requiring a name constraint system for secondary issuers). Please see the [Security Considerations](#6-security-considerations) section for more information on this topic.
 
 For more information about how a trust domain namespace is represented, please see [Section 2][1] of the SPIFFE ID specification.
 

--- a/standards/SPIFFE_Workload_API.md
+++ b/standards/SPIFFE_Workload_API.md
@@ -210,7 +210,7 @@ The `X509BundlesResponse` response message has a mandatory `bundles` field, whic
 
 If the client is not entitled to receive any X.509 bundles, then the server SHOULD respond with the "PermissionDenied" gRPC status code (see the [Error Codes](SPIFFE_Workload_Endpoint.md#6-error-codes) section in the SPIFFE Workload Endpoint specification for more information). The client MAY attempt to reconnect with another call to the `FetchX509Bundles` RPC after a backoff.
 
-As mentioned in [Stream Responses](#43-stream-responses), each `X509BundleResponse` response contains the complete set of authorized X.509 bundles for the client at that point in time. As such, if the server redacts bundles from a subsequent response (or all bundles, i.e., returns a "PermissionDenied" gRPC status code) the client SHOULD cease using the redacted bundles.
+As mentioned in [Stream Responses](#43-stream-responses), each `X509BundlesResponse` response contains the complete set of authorized X.509 bundles for the client at that point in time. As such, if the server redacts bundles from a subsequent response (or all bundles, i.e., returns a "PermissionDenied" gRPC status code) the client SHOULD cease using the redacted bundles.
 
 ### 5.3 Default Identity
 
@@ -344,7 +344,7 @@ The returned bundles are encoded as a standard JWK Set as defined by [RFC 7517](
 
 If the client is not entitled to receive any JWT bundles, then the server SHOULD respond with the "PermissionDenied" gRPC status code (see the [Error Codes](SPIFFE_Workload_Endpoint.md#6-error-codes) section in the SPIFFE Workload Endpoint specification for more information). The client MAY attempt to reconnect with another call to the `FetchJWTBundles` RPC after a backoff.
 
-As mentioned in [Stream Responses](#43-stream-responses), each `JWTBundleResponse` response contains the complete set of authorized JWT bundles for the client at that point in time. As such, if the server redacts bundles from a subsequent response (or all bundles, i.e., returns a "PermissionDenied" gRPC status code) the client SHOULD cease using the redacted bundles.
+As mentioned in [Stream Responses](#43-stream-responses), each `JWTBundlesResponse` response contains the complete set of authorized JWT bundles for the client at that point in time. As such, if the server redacts bundles from a subsequent response (or all bundles, i.e., returns a "PermissionDenied" gRPC status code) the client SHOULD cease using the redacted bundles.
 
 #### 6.2.3 ValidateJWTSVID
 

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -36,7 +36,7 @@ Perhaps the most important function of SPIFFE is to secure process to process co
 This specification addresses the encoding of SVID information into an X.509 certificate, the constraints which must be set, as well as how to validate X.509 SVIDs.
 
 ## 2. SPIFFE ID
-In an X.509 SVID, the corresponding SPIFFE ID is set as a URI type in the Subject Alternative Name extension (SAN extension, see [RFC 5280 section 4.2.16][2]). An X.509 SVID MUST contain exactly one URI SAN, and by extension, exactly one SPIFFE ID. SVIDs containing more than one SPIFFE ID introduce challenges related to auditing and authorization logic, and SVIDs containing more than one URI SAN introduce challenges related to SPIFFE ID validation. Validators encountering an SVID containing more than one URI SAN MUST reject the SVID. Please see the [Validation](#5-validation) section for more information.
+In an X.509 SVID, the corresponding SPIFFE ID is set as a URI type in the Subject Alternative Name extension (SAN extension, see [RFC 5280 section 4.2.1.6][2]). An X.509 SVID MUST contain exactly one URI SAN, and by extension, exactly one SPIFFE ID. SVIDs containing more than one SPIFFE ID introduce challenges related to auditing and authorization logic, and SVIDs containing more than one URI SAN introduce challenges related to SPIFFE ID validation. Validators encountering an SVID containing more than one URI SAN MUST reject the SVID. Please see the [Validation](#5-validation) section for more information.
 
 An X.509 SVID MAY contain any number of other SAN field types, including DNS SANs.
 
@@ -97,7 +97,7 @@ Certificate path validation requires the leaf SVID certificate and one or more S
 ### 5.2. Leaf Validation
 When authenticating a resource or caller, it is necessary to perform validation beyond what is covered by the X.509 standard. Namely, we must ensure that 1) the certificate is a leaf certificate, and 2) that the signing authority was authorized to issue it.
 
-When validating an X.509 SVID for authentication purposes, the validator MUST ensure that the `CA` field in the basic constraints extension is set to `false`, and that `keyCertSign` and `cRLSign` are not set in the key usage extension. The validator MUST also ensure that the scheme of the SPIFFE ID is set to `spiffe`, and MUST ensure that the SPIFFE ID has a non-root path component. SVIDs containing more than one URI SAN MUST be rejected.
+When validating an X.509 SVID for authentication purposes, the validator MUST ensure that the `cA` field in the basic constraints extension is set to `false`, and that `keyCertSign` and `cRLSign` are not set in the key usage extension. The validator MUST also ensure that the scheme of the SPIFFE ID is set to `spiffe`, and MUST ensure that the SPIFFE ID has a non-root path component. SVIDs containing more than one URI SAN MUST be rejected.
 
 As support for URI name constraints becomes more widespread, future versions of this document may update the requirements set forth in this section in order to better leverage name constraint validation.
 
@@ -124,9 +124,9 @@ This document set forth conventions and standards for the issuance and validatio
 ## Appendix A. X.509 Field Reference
 Extension | Field | Description
 ----------|-------|------------
-Subject Alternate Name | uniformResourceIdentifier | This field is set equal to the SPIFFE ID. Only one instance of this field is permitted.
+Subject Alternative Name | uniformResourceIdentifier | This field is set equal to the SPIFFE ID. Only one instance of this field is permitted.
 Basic Constraints | CA | This field must be set to `true` if and only if the SVID is a signing certificate.
-Basic Constraints | pathLenConstraint | This field may be be set if the implementor wishes to enforce a finite CA hierarchy depth, for example, if inherited from an existing private key infrastructure (PKI).
+Basic Constraints | pathLenConstraint | This field may be set if the implementor wishes to enforce a finite CA hierarchy depth, for example, if inherited from an existing private key infrastructure (PKI).
 Name Constraints | permittedSubtrees | This field may be set if the implementor wishes to use URI name constraints. It will be required in a future version of this document.
 Key Usage | keyCertSign | This field must be set if and only if the SVID is a signing certificate.
 Key Usage | cRLSign | This field may be set if and only if the SVID is a signing certificate.


### PR DESCRIPTION
A series of minor changes to fix:

- Spelling
- Grammar
- Incorrect markdown references
- Missing sections from indexes