### PR TITLE
Nominate Sorin Dumitru

### DIFF
--- a/ssc/elections/2026H1/SORIN_DUMITRU.md
+++ b/ssc/elections/2026H1/SORIN_DUMITRU.md
@@ -1,0 +1,10 @@
+# Sorin Dumitru
+
+Sorin is one of the SPIRE maintainers and active member of the SPIFFE sig-spec.
+You will most likely have interacted with him when needing help with SPIRE issues
+on the SPIFFE Slack. In his day job he’s an active user of SPIFFE and SPIRE at Bloomberg
+
+**GitHub Handle:** @sorindumitru  
+**Email Address:** sorin@returnze.ro  
+**LinkedIn Profile:** https://www.linkedin.com/in/sorin-dumitru-69841243  
+**Current Affiliation:** Bloomberg  


### PR DESCRIPTION
I hereby nominate Sorin Dumitru for the 2026H1 SSC election.

In the past couple of years, Sorin has been a very valuable and active participant in SIG-Spec. He brings a fresh perspective as an end-user of SPIFFE/SPIRE, but also a depth of knowledge from his position as a maintainer of SPIRE. I believe this perspective and depth of knowledge would be extremely valuable in SSC.