### PR TITLE
standards: fix typo succesfully -> successfully in workloadapi.proto

### DIFF
--- a/standards/SPIFFE_Workload_API.md
+++ b/standards/SPIFFE_Workload_API.md
@@ -297,7 +297,7 @@ message JWTBundlesResponse {
 message ValidateJWTSVIDRequest {
     // Required. The audience of the validating party. The JWT-SVID must
     // contain an audience claim which contains this value in order to
-    // succesfully validate.
+    // successfully validate.
     string audience = 1;
 
     // Required. The JWT-SVID to validate, encoded using JWS Compact

--- a/standards/workloadapi.proto
+++ b/standards/workloadapi.proto
@@ -145,7 +145,7 @@ message JWTBundlesResponse {
 message ValidateJWTSVIDRequest {
     // Required. The audience of the validating party. The JWT-SVID must
     // contain an audience claim which contains this value in order to
-    // succesfully validate.
+    // successfully validate.
     string audience = 1;
 
     // Required. The JWT-SVID to validate, encoded using JWS Compact

--- a/standards/workloadapi.proto
+++ b/standards/workloadapi.proto
@@ -165,7 +165,7 @@ message JWTBundlesResponse {
 message ValidateJWTSVIDRequest {
     // Required. The audience of the validating party. The JWT-SVID must
     // contain an audience claim which contains this value in order to
-    // succesfully validate.
+    // successfully validate.
     string audience = 1;
 
     // Required. The JWT-SVID to validate, encoded using JWS Compact


### PR DESCRIPTION
Minor typo fix in proto comment.