### PR TITLE
Introduce Stability/Graduation process for SPIFFE specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ SPIFFE is a [graduated](https://www.cncf.io/projects/spiffe/) project of the [Cl
 * [SPIFFE Federation](standards/SPIFFE_Federation.md)
 * [The SPIFFE Broker API](standards/SPIFFE_Broker_API.md)
 * [The SPIFFE Broker Endpoint](standards/SPIFFE_Broker_Endpoint.md)
+* [SPIFFE Specification Stability](standards/STABILITY.md)
 
 ## Getting Started
 

--- a/standards/JWT-SVID.md
+++ b/standards/JWT-SVID.md
@@ -1,5 +1,7 @@
 # The JWT SPIFFE Verifiable Identity Document
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity document standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 

--- a/standards/SPIFFE-ID.md
+++ b/standards/SPIFFE-ID.md
@@ -1,5 +1,7 @@
 # The SPIFFE Identity and Verifiable Identity Document
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity and identity issuance standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 

--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -54,6 +54,7 @@ The Workload API is defined in the [SPIFFE Workload API](SPIFFE_Workload_API.md)
 This document covered, at a high level, the various components that make up the SPIFFE specification as a whole. Together, these components solve many of the authentication and traffic security challenges presented in modern, heterogeneous environments, particularly those which are highly dynamic. For more detailed information, please see the specification(s) related to the component of interest.
 
 ## Appendix A. List of SPIFFE Specifications
+
 * [The SPIFFE Identity and Verifiable Identity Document](SPIFFE-ID.md)
 * [The X.509 SPIFFE Verifiable Identity Document](X509-SVID.md)
 * [The JWT SPIFFE Verifiable Identity Document](JWT-SVID.md)
@@ -61,3 +62,4 @@ This document covered, at a high level, the various components that make up the 
 * [The SPIFFE Workload API](SPIFFE_Workload_API.md)
 * [The SPIFFE Trust Domain and Bundle](SPIFFE_Trust_Domain_and_Bundle.md)
 * [SPIFFE Federation](SPIFFE_Federation.md)
+* [Stability](STABILITY.md)

--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -64,4 +64,4 @@ This document covered, at a high level, the various components that make up the 
 * [SPIFFE Federation](SPIFFE_Federation.md)
 * [The SPIFFE Broker API](SPIFFE_Broker_API.md)
 * [The SPIFFE Broker Endpoint](SPIFFE_Broker_Endpoint.md)
-* [Stability](STABILITY.md)
+* [SPIFFE Specification Stability](STABILITY.md)

--- a/standards/SPIFFE.md
+++ b/standards/SPIFFE.md
@@ -1,5 +1,7 @@
 # Secure Production Identity Framework for Everyone (SPIFFE)
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity and identity issuance standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 

--- a/standards/SPIFFE_Broker_API.md
+++ b/standards/SPIFFE_Broker_API.md
@@ -1,6 +1,6 @@
 # The SPIFFE Broker API
 
-> **Stability: Beta** - see [STABILITY.md](STABILITY.md).
+> **Stability: Incubating** - see [STABILITY.md](STABILITY.md).
 
 ## Status of this Memo
 

--- a/standards/SPIFFE_Broker_Endpoint.md
+++ b/standards/SPIFFE_Broker_Endpoint.md
@@ -1,6 +1,6 @@
 # The SPIFFE Broker Endpoint
 
-> **Stability: Beta** - see [STABILITY.md](STABILITY.md).
+> **Stability: Incubating** - see [STABILITY.md](STABILITY.md).
 
 ## Status of this Memo
 

--- a/standards/SPIFFE_Federation.md
+++ b/standards/SPIFFE_Federation.md
@@ -1,5 +1,7 @@
 # SPIFFE Federation
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity API standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 

--- a/standards/SPIFFE_Trust_Domain_and_Bundle.md
+++ b/standards/SPIFFE_Trust_Domain_and_Bundle.md
@@ -1,5 +1,7 @@
 # The SPIFFE Trust Domain and Bundle
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity document standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 

--- a/standards/SPIFFE_Workload_API.md
+++ b/standards/SPIFFE_Workload_API.md
@@ -1,5 +1,7 @@
 # The SPIFFE Workload API
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 
 This document specifies an identity API standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.

--- a/standards/SPIFFE_Workload_Endpoint.md
+++ b/standards/SPIFFE_Workload_Endpoint.md
@@ -1,5 +1,7 @@
 # The SPIFFE Workload Endpoint
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 
 This document specifies an identity endpoint standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -4,7 +4,7 @@
 1\. [What this is](#1-what-this-is)  
 2\. [Stability levels](#2-stability-levels)  
 2.1. [Proposed](#21-proposed)  
-2.2. [Beta](#22-beta)  
+2.2. [Incubating](#22-incubating)  
 2.3. [Stable](#23-stable)  
 3\. [Marking stability](#3-marking-stability)  
 3.1. [Marking part of a specification](#31-marking-part-of-a-specification)  
@@ -25,10 +25,10 @@ implementations at any maturity, and vice versa.
   - *Breaking-change contract:* anything may change or be removed at any time, without notice.
   - *Where it lives:* an open PR or proposal. Not merged into the `main` branch.
   - *Audience:* discussion in SIG-Spec and proof of concept implementations.
-- **Beta**
+- **Incubating**
   - *Breaking-change contract:* breaking changes are avoided, but may be made in response to real-world implementation experience.
-  - *Where it lives:* merged into the `main` branch, marked Beta.
-  - *Audience:* implementers willing to track changes and provide feedback. Features relying on a Beta specification are typically gated behind a feature flag.
+  - *Where it lives:* merged into the `main` branch, marked Incubating.
+  - *Audience:* implementers willing to track changes and provide feedback. Features relying on an Incubating specification are typically gated behind a feature flag.
 - **Stable**
   - *Breaking-change contract:* breaking changes are severely avoided and reserved for resolving critical security issues.
   - *Where it lives:* merged into the `main` branch, marked Stable.
@@ -45,46 +45,47 @@ Because Proposed specifications live in PRs rather than in `main`, they require
 no in-document stability marking - the fact that a specification is unmerged
 indicates that it is Proposed.
 
-### 2.2. Beta
+### 2.2. Incubating
 
-A specification is promoted from Proposed to **Beta** by a pull request that
-merges it into the `main` branch with a Beta banner, approved by two
+A specification is promoted from Proposed to **Incubating** by a pull request
+that merges it into the `main` branch with an Incubating banner, approved by two
 maintainers. The criterion for promotion is SIG-Spec consensus that its design
 is sound and ready for trial implementation.
 
-When implementing a Beta specification, it is recommended that adopters record
-the revision of the specification that they have implemented. A permalink to
-the document on GitHub or the commit hash is sufficient for this purpose.
+When implementing an Incubating specification, it is recommended that adopters
+record the revision of the specification that they have implemented. A permalink
+to the document on GitHub or the commit hash is sufficient for this purpose.
 
-Adopters implementing a Beta specification are encouraged to discuss their
-experience and raise feedback with SIG-Spec, so that any rough edges can be
-ironed out before it is promoted to Stable.
+Adopters implementing an Incubating specification are encouraged to discuss
+their experience and raise feedback with SIG-Spec, so that any rough edges can
+be ironed out before it is promoted to Stable.
 
-We avoid making breaking changes to Beta specifications. However, the purpose of
-the Beta phase is to gather experience from real implementations, and that
-experience may occasionally force a breaking change.
+We avoid making breaking changes to Incubating specifications. However, the
+purpose of the Incubating phase is to gather experience from real
+implementations, and that experience may occasionally force a breaking change.
 
 Where breaking changes must be made, the change should be clearly communicated
 along with advice on adjusting implementations. This should be included within
 the document itself within an appendix.
 
 Due to the potential for breaking changes, we typically expect implementations
-of a Beta specification to gate it behind a feature flag (or equivalent opt-in),
-rather than enabling it by default. This makes it clear to operators that they
-are relying on functionality that may still change, and keeps a Beta feature
-from becoming a de-facto stable one purely by virtue of being widely deployed.
+of an Incubating specification to gate it behind a feature flag (or equivalent
+opt-in), rather than enabling it by default. This makes it clear to operators
+that they are relying on functionality that may still change, and keeps an
+Incubating feature from becoming a de-facto stable one purely by virtue of being
+widely deployed.
 
 ### 2.3. Stable
 
-A specification is promoted from Beta to **Stable** by a pull request that
+A specification is promoted from Incubating to **Stable** by a pull request that
 updates its banner, approved by two maintainers. The criterion for promotion is
 that at least two independent, interoperable implementations exist and no
 further breaking changes are anticipated.
 
 Breaking changes to a Stable specification are severely avoided and reserved for
 resolving critical security issues. A Stable specification cannot be demoted
-back to Beta, but may be extended in a non-breaking way with new sections or
-profiles marked Beta.
+back to Incubating, but may be extended in a non-breaking way with new sections
+or profiles marked Incubating.
 
 ## 3. Marking stability
 
@@ -92,7 +93,7 @@ A specification declares its level with a banner immediately beneath the title,
 above the existing "Status of this Memo" section. Use the variant matching the
 level:
 
-> **Stability: Beta** - see [STABILITY.md](STABILITY.md).
+> **Stability: Incubating** - see [STABILITY.md](STABILITY.md).
 
 > **Stability: Stable** - see [STABILITY.md](STABILITY.md).
 
@@ -106,5 +107,5 @@ stability whilst that part is still being proven.
 
 An override is declared inline at the head of the section:
 
-> **Stability: Beta** (this section only - the remainder of this document is
-> Stable.)
+> **Stability: Incubating** (this section only - the remainder of this document
+> is Stable.)

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -52,22 +52,27 @@ merges it into the `main` branch with a Beta banner, approved by two
 maintainers. The criterion for promotion is SIG-Spec consensus that its design
 is sound and ready for trial implementation.
 
-We avoid breaking changes to Beta specifications. However, the purpose of the
-Beta phase is to gather experience from real implementations, and that
-experience may occasionally force a breaking change. Where it does, the change
-should be clearly communicated along with advice on adjusting implementations.
-Adopters should expect to track such changes and pin to a specific revision.
+When implementing a Beta specification, it is recommended that adopters record
+the revision of the specification that they have implemented. A permalink to
+the document on GitHub or the commit hash is sufficient for this purpose.
 
-This feedback loop is the point of the Beta phase: we encourage those
-implementing a Beta specification to discuss their experience and raise feedback
-with SIG-Spec, so that any rough edges can be ironed out before it is promoted
-to Stable.
+Adopters implementing a Beta specification are encouraged to discuss their
+experience and raise feedback with SIG-Spec, so that any rough edges can be
+ironed out before it is promoted to Stable.
 
-For this reason, we typically expect implementations of a Beta specification to
-gate it behind a feature flag (or equivalent opt-in), rather than enabling it by
-default. This makes it clear to operators that they are relying on functionality
-that may still change, and keeps a Beta feature from becoming a de-facto stable
-one purely by virtue of being widely deployed.
+We avoid making breaking changes to Beta specifications. However, the purpose of
+the Beta phase is to gather experience from real implementations, and that
+experience may occasionally force a breaking change.
+
+Where breaking changes must be made, the change should be clearly communicated
+along with advice on adjusting implementations. This should be included within
+the document itself within an appendix.
+
+Due to the potential for breaking changes, we typically expect implementations
+of a Beta specification to gate it behind a feature flag (or equivalent opt-in),
+rather than enabling it by default. This makes it clear to operators that they
+are relying on functionality that may still change, and keeps a Beta feature
+from becoming a de-facto stable one purely by virtue of being widely deployed.
 
 ### 2.3. Stable
 

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -49,7 +49,7 @@ indicates that it is Proposed.
 
 A specification is promoted from Proposed to **Incubating** by a pull request
 that merges it into the `main` branch with an Incubating banner, approved by two
-maintainers. The criterion for promotion is SIG-Spec consensus that its design
+code owners. The criterion for promotion is SIG-Spec consensus that its design
 is sound and ready for trial implementation.
 
 When implementing an Incubating specification, it is recommended that adopters
@@ -78,7 +78,7 @@ widely deployed.
 ### 2.3. Stable
 
 A specification is promoted from Incubating to **Stable** by a pull request that
-updates its banner, approved by two maintainers. The criterion for promotion is
+updates its banner, approved by two code owners. The criterion for promotion is
 that at least two independent, interoperable implementations exist and no
 further breaking changes are anticipated.
 

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -3,8 +3,8 @@
 ## Table of Contents
 1\. [What this is](#1-what-this-is)  
 2\. [Stability levels](#2-stability-levels)  
-2.1. [Proposed](#21-proposed)
-2.2. [Experimental](#22-experimental)
+2.1. [Proposed](#21-proposed)  
+2.2. [Experimental](#22-experimental)  
 2.3. [Incubating](#23-incubating)  
 2.4. [Stable](#24-stable)  
 3\. [Marking stability](#3-marking-stability)  

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -78,9 +78,17 @@ widely deployed.
 ### 2.3. Stable
 
 A specification is promoted from Incubating to **Stable** by a pull request that
-updates its banner, approved by two code owners. The criterion for promotion is
-that at least two independent, interoperable implementations exist and no
-further breaking changes are anticipated.
+updates its banner, approved by two code owners.
+
+Promotion is ultimately at the behest of the code owners. It is not gated on
+any fixed criteria, however, the code owners should be satisfied that it is 
+unlikely that any significant or breaking changes will be required in the
+future.
+
+Typically, a specification is ready for promotion when there are multiple
+independent implementations and there are real-world deployments that have
+proven that the specification is fit for purpose. In practice, different
+criteria may be more appropriate depending on what the specification defines.
 
 Breaking changes to a Stable specification are severely avoided and reserved for
 resolving critical security issues. A Stable specification cannot be demoted

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -1,0 +1,104 @@
+# SPIFFE Specification Stability
+
+## Table of Contents
+1\. [What this is](#1-what-this-is)  
+2\. [Stability levels](#2-stability-levels)  
+2.1. [Proposed](#21-proposed)  
+2.2. [Beta](#22-beta)  
+2.3. [Stable](#23-stable)  
+3\. [Marking stability](#3-marking-stability)  
+3.1. [Marking part of a specification](#31-marking-part-of-a-specification)  
+
+## 1. What this is
+
+This document defines stability levels for SPIFFE *specifications* and the
+process for moving a specification between them.
+
+This is distinct from [MATURITY.md](/MATURITY.md), which describes the maturity
+of SPIFFE *software projects* (e.g. SPIRE). A specification's stability and an
+implementation's maturity are separate axes - a Stable specification may have
+implementations at any maturity, and vice versa.
+
+## 2. Stability levels
+
+- **Proposed**
+  - *Breaking-change contract:* anything may change or be removed at any time, without notice.
+  - *Where it lives:* an open PR or proposal. Not merged into the `main` branch.
+  - *Audience:* discussion in SIG-Spec and proof of concept implementations.
+- **Beta**
+  - *Breaking-change contract:* breaking changes are avoided, but may be made in response to real-world implementation experience.
+  - *Where it lives:* merged into the `main` branch, marked Beta.
+  - *Audience:* implementers willing to track changes and provide feedback. Features relying on a Beta specification are typically gated behind a feature flag.
+- **Stable**
+  - *Breaking-change contract:* breaking changes are severely avoided and reserved for resolving critical security issues.
+  - *Where it lives:* merged into the `main` branch, marked Stable.
+  - *Audience:* anyone, including production-critical use.
+
+### 2.1. Proposed
+
+A specification is **Proposed** by default whilst it lives in an open pull
+request or proposal. It has not yet been merged into the `main` branch. SIG-Spec
+may still be debating its shape, and any part of it may change or be dropped
+entirely.
+
+Because Proposed specifications live in PRs rather than in `main`, they require
+no in-document stability marking - the fact that a specification is unmerged
+indicates that it is Proposed.
+
+### 2.2. Beta
+
+A specification is promoted from Proposed to **Beta** by a pull request that
+merges it into the `main` branch with a Beta banner, approved by two
+maintainers. The criterion for promotion is SIG-Spec consensus that its design
+is sound and ready for trial implementation.
+
+We avoid breaking changes to Beta specifications. However, the purpose of the
+Beta phase is to gather experience from real implementations, and that
+experience may occasionally force a breaking change. Where it does, the change
+should be clearly communicated along with advice on adjusting implementations.
+Adopters should expect to track such changes and pin to a specific revision.
+
+This feedback loop is the point of the Beta phase: we encourage those
+implementing a Beta specification to discuss their experience and raise feedback
+with SIG-Spec, so that any rough edges can be ironed out before it is promoted
+to Stable.
+
+For this reason, we typically expect implementations of a Beta specification to
+gate it behind a feature flag (or equivalent opt-in), rather than enabling it by
+default. This makes it clear to operators that they are relying on functionality
+that may still change, and keeps a Beta feature from becoming a de-facto stable
+one purely by virtue of being widely deployed.
+
+### 2.3. Stable
+
+A specification is promoted from Beta to **Stable** by a pull request that
+updates its banner, approved by two maintainers. The criterion for promotion is
+that at least two independent, interoperable implementations exist and no
+further breaking changes are anticipated.
+
+Breaking changes to a Stable specification are severely avoided and reserved for
+resolving critical security issues. A Stable specification cannot be demoted
+back to Beta, but may be extended in a non-breaking way with new sections or
+profiles marked Beta.
+
+## 3. Marking stability
+
+A specification declares its level with a banner immediately beneath the title,
+above the existing "Status of this Memo" section. Use the variant matching the
+level:
+
+> **Stability: Beta** - see [STABILITY.md](STABILITY.md).
+
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
+### 3.1. Marking part of a specification
+
+A section inherits the stability of the document it sits in unless it carries
+its own marker. This lets a mature specification grow a less-baked addition
+without dragging the whole document down a level. For example, an otherwise
+Stable specification may define a specific profile, or a set of RPCs, at a lower
+stability whilst that part is still being proven. An override is declared inline
+at the head of the section:
+
+> **Stability: Beta** (this section only - the remainder of this document is
+> Stable.)

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -3,9 +3,10 @@
 ## Table of Contents
 1\. [What this is](#1-what-this-is)  
 2\. [Stability levels](#2-stability-levels)  
-2.1. [Proposed](#21-proposed)  
-2.2. [Incubating](#22-incubating)  
-2.3. [Stable](#23-stable)  
+2.1. [Proposed](#21-proposed)
+2.2. [Experimental](#22-experimental)
+2.3. [Incubating](#23-incubating)  
+2.4. [Stable](#24-stable)  
 3\. [Marking stability](#3-marking-stability)  
 3.1. [Marking part of a specification](#31-marking-part-of-a-specification)  
 
@@ -15,9 +16,8 @@ This document defines stability levels for SPIFFE *specifications* and the
 process for moving a specification between them.
 
 This is distinct from [MATURITY.md](/MATURITY.md), which describes the maturity
-of SPIFFE *software projects* (e.g. SPIRE). A specification's stability and an
-implementation's maturity are separate axes - a Stable specification may have
-implementations at any maturity, and vice versa.
+of SPIFFE *software projects* (e.g. SPIRE). This document (STABILITY.md) is
+only concerned with the stability of specifications.
 
 ## 2. Stability levels
 
@@ -25,6 +25,10 @@ implementations at any maturity, and vice versa.
   - *Breaking-change contract:* anything may change or be removed at any time, without notice.
   - *Where it lives:* an open PR or proposal. Not merged into the `main` branch.
   - *Audience:* discussion in SIG-Spec and proof of concept implementations.
+- **Experimental**
+  - *Breaking-change contract:* anything may change or be removed at any time, via a PR process.
+  - *Where it lives:* merged into the `main` branch, marked Experimental.
+  - *Audience:* discussion in SIG-Spec, collecting interest and proof of concept implementations.
 - **Incubating**
   - *Breaking-change contract:* breaking changes are avoided, but may be made in response to real-world implementation experience.
   - *Where it lives:* merged into the `main` branch, marked Incubating.
@@ -45,12 +49,32 @@ Because Proposed specifications live in PRs rather than in `main`, they require
 no in-document stability marking - the fact that a specification is unmerged
 indicates that it is Proposed.
 
-### 2.2. Incubating
+### 2.2. Experimental
 
-A specification is promoted from Proposed to **Incubating** by a pull request
-that merges it into the `main` branch with an Incubating banner, approved by two
-code owners. The criterion for promotion is SIG-Spec consensus that its design
-is sound and ready for trial implementation.
+The **Experimental** stability level is an optional intermediate level between
+Proposed and Incubating. It is intended for specifications that may not have
+a clear demand or direction, and for which SIG-Spec would like to gauge interest
+and collect proof-of-concept implementations before committing to a design.
+
+Whether a specification should utilize the Experimental level is at the
+discretion of the SPIFFE maintainers.
+
+There is no formal compatibility guarantee for Experimental specifications and 
+an Experimental specification may be changed or removed at any time.
+
+### 2.3. Incubating
+
+A specification may move to **Incubating** via two routes:
+
+- Directly from Proposed: where the PR containing the specification is merged
+  into `main` with the Incubating banner. This PR must be approved by two
+  maintainers.
+- From Experimental: where the specification already exists in `main` with the
+  Experimental banner, and a PR is raised to update the banner to Incubating.
+  This PR must be approved by two maintainers.
+
+The criterion for promotion to Incubating is SIG-Spec consensus that the design
+is sound and ready for trial implementations.
 
 When implementing an Incubating specification, it is recommended that adopters
 record the revision of the specification that they have implemented. A permalink
@@ -75,13 +99,13 @@ that they are relying on functionality that may still change, and keeps an
 Incubating feature from becoming a de-facto stable one purely by virtue of being
 widely deployed.
 
-### 2.3. Stable
+### 2.4. Stable
 
 A specification is promoted from Incubating to **Stable** by a pull request that
-updates its banner, approved by two code owners.
+updates its banner, approved by two maintainers. 
 
-Promotion is ultimately at the behest of the code owners. It is not gated on
-any fixed criteria, however, the code owners should be satisfied that it is 
+Promotion is ultimately at the behest of the maintainers. It is not gated on
+any fixed criteria, however, the maintainers should be satisfied that it is 
 unlikely that any significant or breaking changes will be required in the
 future.
 
@@ -101,6 +125,8 @@ or profiles marked Incubating.
 A specification declares its level with a banner immediately beneath the title,
 above the existing "Status of this Memo" section. Use the variant matching the
 level:
+
+> **Stability: Experimental** - see [STABILITY.md](STABILITY.md).
 
 > **Stability: Incubating** - see [STABILITY.md](STABILITY.md).
 

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -86,9 +86,10 @@ unlikely that any significant or breaking changes will be required in the
 future.
 
 Typically, a specification is ready for promotion when there are multiple
-independent implementations and there are real-world deployments that have
-proven that the specification is fit for purpose. In practice, different
-criteria may be more appropriate depending on what the specification defines.
+distinct and interoperable implementations and there are real-world deployments
+that have proven that the specification is fit for purpose. In practice,
+different criteria may be more appropriate depending on what the specification
+defines.
 
 Breaking changes to a Stable specification are severely avoided and reserved for
 resolving critical security issues. A Stable specification cannot be demoted

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -74,7 +74,7 @@ A specification may move to **Incubating** via two routes:
   This PR must be approved by two maintainers.
 
 The criterion for promotion to Incubating is SIG-Spec consensus that the design
-is sound and ready for trial implementations.
+is sound and ready for real world scenarios.
 
 When implementing an Incubating specification, it is recommended that adopters
 record the revision of the specification that they have implemented. A permalink

--- a/standards/STABILITY.md
+++ b/standards/STABILITY.md
@@ -102,8 +102,9 @@ A section inherits the stability of the document it sits in unless it carries
 its own marker. This lets a mature specification grow a less-baked addition
 without dragging the whole document down a level. For example, an otherwise
 Stable specification may define a specific profile, or a set of RPCs, at a lower
-stability whilst that part is still being proven. An override is declared inline
-at the head of the section:
+stability whilst that part is still being proven.
+
+An override is declared inline at the head of the section:
 
 > **Stability: Beta** (this section only - the remainder of this document is
 > Stable.)

--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -1,5 +1,7 @@
 # The X.509 SPIFFE Verifiable Identity Document
 
+> **Stability: Stable** - see [STABILITY.md](STABILITY.md).
+
 ## Status of this Memo
 This document specifies an identity document standard for the internet community, and requests discussion and suggestions for improvements. Distribution of this document is unlimited.
 


### PR DESCRIPTION
With the recent work on Broker API and WIT-SVID profile, it's become apparent that we need some way of tracking and communicating the stability on specifications.

Previously, we roughly settled on content within the `main` branch being "Stable" and experimental or in-progress specs being held within branches/PRs. This has posed a number of challenges:

1. It reduces discoverability of newer specifications as they can only be found directly on GitHub within PRs.
2. It reduces confidence of implementors - it's unclear /when/ they should start to produce downstream implementations and what they should expect.
3. It poses some devex/logistical pain in managing the seperate branches.

This PR takes a stab at a stability/graduation process for SPIFFE specs. I've tried to keep it very light-weight as we don't need to burden ourselves with significant bureacracy. This process should let us move /faster/ rather than slow us down.