### PR TITLE
Update SIG-Spec meeting time and chair in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Most community activity is organized into Special Interest Groups (SIGs), time-b
 | Name | Lead | Group | Slack Channel | Meetings |
 |:------:|:-------:|:-------:|:---------------:|:----------:|
 | [SIG-Community](/community/sig-community/README.md) | [Umair Khan](https://github.com/umairmkhan) (HPE) | [Here](https://groups.google.com/a/spiffe.io/g/sig-community) | [Here](https://spiffe.slack.com/messages/community) | [Notes](https://docs.google.com/document/d/1tb3lxubwr8IKRd6Smnl83ur14xkOQdjwQqla9OHjwZo) |
-| [SIG-Spec](/community/sig-spec/README.md) | [Evan Gilman](https://github.com/evan2645) (VMware) | [Here](https://groups.google.com/a/spiffe.io/forum/#!forum/sig-specification) | [Here](https://spiffe.slack.com/messages/sig-spec) | [Notes](https://docs.google.com/document/d/1f64vbyn5sOb8Mr1H3mGGGul3vTKo4r6cTBcUV3N9OFo) |
+| [SIG-Spec](/community/sig-spec/README.md) | Vacant | [Here](https://groups.google.com/a/spiffe.io/forum/#!forum/sig-specification) | [Here](https://spiffe.slack.com/messages/sig-spec) | [Notes](https://docs.google.com/document/d/1f64vbyn5sOb8Mr1H3mGGGul3vTKo4r6cTBcUV3N9OFo) |
 | [SIG-SPIRE](/community/sig-spire/README.md) | [Daniel Feldman](https://github.com/dfeldman) (HPE) | [Here](https://groups.google.com/a/spiffe.io/forum/#!forum/sig-spire) | [Here](https://spiffe.slack.com/messages/spire) | [Notes](https://docs.google.com/document/d/1IgpCkvSRSoY9Xd16gFQJJ1KP8sLZ7EE39cEjBK_UIg4) |
 
 **Follow the SPIFFE Project** You can find us on [Github](https://github.com/spiffe/) and [Twitter](https://twitter.com/SPIFFEio).

--- a/community/sig-spec/README.md
+++ b/community/sig-spec/README.md
@@ -3,7 +3,7 @@
 A Special Interest Group (SIG) concerning the official SPIFFE specifications.
 
 ### Meetings:
-* Date/Time: Every Thursday @ 9:30AM PST
+* Date/Time: Every Thursday @ 9:00AM PST
 * [Meetings Notes](https://docs.google.com/document/d/1f64vbyn5sOb8Mr1H3mGGGul3vTKo4r6cTBcUV3N9OFo)
 * [Calendar ICS](https://calendar.google.com/calendar/ical/spiffe.io_0h88o393t6qi5q55h0v9u66j50%40group.calendar.google.com/public/basic.ics) (See this [Google support page](https://support.google.com/calendar/answer/37100?co=GENIE.Platform%3DDesktop&hl=en) to learn more about importing .ics files)
 
@@ -22,4 +22,4 @@ A Special Interest Group (SIG) concerning the official SPIFFE specifications.
 * SPIRE maintenance
 
 ### Leads:
-* Evan Gilman ([GitHub](https://github.com/evan2645) / [LinkedIn](https://www.linkedin.com/in/evan2645/))
+* Vacant 


### PR DESCRIPTION
Updates various READMEs to reflect the changed SIG-Spec meeting time and Evan's resignation from SPIFFE maintainership/SIG-Spec.