### PR TITLE
Replace spikecurtis with sorindumitru as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 ## SPIFFE Maintainers
 ##
 
-*  @arndt-s @spikecurtis @strideynet @azdagron
+*  @arndt-s @sorindumitru @strideynet @azdagron
 
 /CODE-OF-CONDUCT.md @spiffe/ssc
 /GOVERNANCE.md      @spiffe/ssc


### PR DESCRIPTION
It's long overdue that I step down from being a maintainer / CODEOWNER on the SPIFFE Specs.

With consultation from currently active maintainers, I nominate @sorindumitru to take my place.

I'm glad to see the community is still active and that the specs are still evolving to meet new needs.