### PR TITLE
Document Private Enterprise Number

### DIFF
--- a/community/sig-spec/iana-pen.md
+++ b/community/sig-spec/iana-pen.md
@@ -8,6 +8,6 @@ The full prefix would be `1.3.6.1.4.1.65980`.
 This PEN is available for use in ASN.1 OID's should SPIFFE ever define any 
 X.509 extensions (or other ASN.1 structures). 
 
-Currently, the SPIFFE standards do not define any OIDs. Should standards ever
-define OIDs using this PEN, this document must be updated to track and reserve
-their use.
+At the time of writing, the SPIFFE standards do not define any OIDs. This
+document should be updated if any OIDs are defined in the future to track 
+assignments.

--- a/community/sig-spec/iana-pen.md
+++ b/community/sig-spec/iana-pen.md
@@ -1,0 +1,13 @@
+# IANA Private Enterprise Number (PEN)
+
+SPIFFE has been assigned the Private Enterprise Number (PEN) 65980 by the 
+Internet Assigned Numbers Authority (IANA).
+
+The full prefix would be `1.3.6.1.4.1.65980`.
+
+This PEN is available for use in ASN.1 OID's should SPIFFE ever define any 
+X.509 extensions (or other ASN.1 structures). 
+
+Currently, the SPIFFE standards do not define any OIDs. Should standards ever
+define OIDs using this PEN, this document must be updated to track and reserve
+their use.


### PR DESCRIPTION
We have been allocated a Private Enterprise Number - I don't know if we'll ever use it - but it's useful to have this documented/around in case we ever wish to define some OIDs for X.509 extensions etc. It's also entirely possible that such work would make more sense under IETF umbrella/IETF OIDs.