### PR TITLE
X509-SVID: require trust-domain-scoped bundle selection in leaf validation (#375)

### DIFF
--- a/standards/X509-SVID.md
+++ b/standards/X509-SVID.md
@@ -96,6 +96,8 @@ The validation of trust in a given SVID is based on standard X.509 path validati
 
 Certificate path validation requires the leaf SVID certificate and one or more SVID signing certificates. The set of signing certificates required for validation is known as the CA bundle. The mechanism through which an entity can retrieve the relevant CA bundle(s) is out of scope for this document, and is instead defined in the [SPIFFE Workload API](SPIFFE_Workload_API.md) specification.
 
+When the validator is configured to trust more than one trust domain, it MUST determine the SVID's trust domain from the trust domain name (the authority component) of the SPIFFE ID in the URI SAN, and MUST perform path validation using only the CA bundle associated with that trust domain. A validator MUST NOT accept an X.509 SVID on the basis that its path is valid against the union of the CA bundles of the trust domains it trusts. Failing to bind validation to the SVID's own trust domain allows a compromised trust domain to issue SVIDs bearing SPIFFE IDs of another trust domain, so that the impact of a compromise is not contained to the affected trust domain. Where supported, URI name constraints (see [Section 5.2](#52-leaf-validation)) are a complementary defense-in-depth mechanism for this binding — particularly for validators that terminate concatenated root pools — but do not replace this requirement.
+
 ### 5.2. Leaf Validation
 When authenticating a resource or caller, it is necessary to perform validation beyond what is covered by the X.509 standard. Namely, we must ensure that 1) the certificate is a leaf certificate, and 2) that the signing authority was authorized to issue it.
 


### PR DESCRIPTION
Addresses #375 (*More explicitly define rules for validating X509-SVIDs in federated environments to avoid cross-trust-domain impersonation*).

### The gap

§5.2 (Leaf Validation) lists the SPIFFE-specific leaf checks (`cA=false`, no `keyCertSign`/`cRLSign`, `spiffe` scheme, non-root path, single URI SAN) but does not state, as a normative requirement, the step that matters once a validator trusts **more than one** trust domain: the §5.1 path must be built against the CA bundle **of the trust domain named in the SVID's own SPIFFE ID**, not against the union of every trusted bundle.

This requirement isn't new — it exists today only as non-normative prose in a *companion* spec, `SPIFFE_Federation.md` §7.3 ("Preserving the `<Trust Domain, Bundle>` Binding"): *"When authenticating an SVID, the verifier must use only the bundle for the trust domain the SPIFFE ID resides in. If we simply pooled all the bundles … then trust domains could easily impersonate each other's identities."* That is a lowercase "must" in a security-considerations section of the federation document, not an RFC 2119 MUST in the X509-SVID spec that validator implementers actually read for the validation procedure.

The consequence is cross-trust-domain impersonation: if `foo.example.com` and `bar.example.com` are federated and `foo` is compromised, `foo`'s CA can mint a leaf carrying `spiffe://bar.example.com/…`, and a validator that checks "is this signed by *any* CA I trust?" accepts it. This is most acute with the common workaround of concatenating all federated roots into one pool for X.509-aware-but-not-SPIFFE-aware software, where nothing else re-establishes the binding.

### Change

Adds one normative paragraph to §5.2 requiring the validator to key path validation off the SVID's own trust domain, and a MUST NOT against accepting on the basis of the union of trusted bundles. Extends the existing name-constraints note to record that URI name constraints are a complementary defense-in-depth mechanism, not a replacement for this binding.

### Notes for the SIG

- **Not already covered by §4.2 of the federation spec**, which is a MUST NOT against merging bundle *contents* at storage time. This is the distinct runtime step: even with bundles stored separately, a validator must select by the SVID's trust domain rather than trying them all.
- **Not a protocol change** — a normative clarification of behavior compliant SPIFFE-native validators already intend (e.g. grpc-java's `XdsX509TrustManager` selects the delegate strictly by the peer SPIFFE ID's trust domain). The value is making it unambiguous for new implementations and for the non-SPIFFE-aware integration path where it's genuinely missed.
- Wording deliberately says "the CA bundle associated with that trust domain" rather than prescribing *how* that association is maintained, since bundle acquisition is out of scope for §5.1.

Happy to adjust the wording to the SIG's preference.
